### PR TITLE
Feat : Spring Security 적용하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,15 +25,15 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // JWT

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/io/powerrangers/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/io/powerrangers/backend/config/JwtAuthenticationFilter.java
@@ -1,0 +1,71 @@
+package io.powerrangers.backend.config;
+
+import io.powerrangers.backend.dto.TokenBody;
+import io.powerrangers.backend.dto.UserDetails;
+import io.powerrangers.backend.entity.User;
+import io.powerrangers.backend.service.CustomOauth2UserService;
+import io.powerrangers.backend.service.JwtProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+    private final CustomOauth2UserService customOauth2UserService;
+    private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+
+    private final List<String> WHITE_LIST = List.of(
+            "/test/**"
+    );
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+        if (token != null && jwtProvider.validateToken(token)) {
+            TokenBody tokenBody = jwtProvider.parseToken(token);
+            UserDetails userDetails = customOauth2UserService.getUserDetails(tokenBody.getUserId());
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    userDetails,
+                    null,
+                    userDetails.getAuthorities()
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            log.error("filter 에서 문제 발생!");
+            throw new RuntimeException("문제가 있는 토큰입니다.");
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return WHITE_LIST.stream()
+                .anyMatch(pattern -> antPathMatcher.match(pattern, path));
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/powerrangers/backend/config/Oauth2SuccessHandler.java
+++ b/src/main/java/io/powerrangers/backend/config/Oauth2SuccessHandler.java
@@ -1,0 +1,70 @@
+package io.powerrangers.backend.config;
+
+import io.powerrangers.backend.dao.UserRepository;
+import io.powerrangers.backend.dto.TokenPair;
+import io.powerrangers.backend.dto.UserDetails;
+import io.powerrangers.backend.entity.RefreshToken;
+import io.powerrangers.backend.entity.User;
+import io.powerrangers.backend.service.JwtProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class Oauth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    // 추후 userService로 바꾸면 좋을 듯
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+    private static final String ACCESS_TOKEN = "accessToken";
+    private static final String REFRESH_TOKEN = "refreshToken";
+    private static final String BASE_URL = "http://localhost:8080/user";
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        UserDetails principal = (UserDetails) authentication.getPrincipal();
+        User findUser = userRepository.findById(principal.getId()).orElseThrow(
+                () -> new RuntimeException("존재하지 않는 유저입니다."));
+
+        HashMap<String, String> paramsMap = new HashMap<>();
+        Optional<RefreshToken> validRefreshToken = jwtProvider.findValidRefreshToken(principal.getId());
+        if (validRefreshToken.isEmpty()) {
+            TokenPair tokenPair = jwtProvider.generateTokenPair(findUser);
+            paramsMap.put(ACCESS_TOKEN, tokenPair.getAccessToken());
+            paramsMap.put(REFRESH_TOKEN, tokenPair.getRefreshToken());
+        } else {
+            String accessToken = jwtProvider.issueAccessToken(findUser.getId(), findUser.getRole());
+            paramsMap.put(ACCESS_TOKEN, accessToken);
+            paramsMap.put(REFRESH_TOKEN, validRefreshToken.get().getRefreshToken());
+        }
+        String url = generateUrlString(paramsMap);
+
+        // 토큰 값을 출력하기 위한 로그 출력
+        log.info("paramsMap.get(ACCESS_TOKEN) = {}", paramsMap.get(ACCESS_TOKEN));
+        log.info("paramsMap.get(REFRESH_TOKEN) = {}", paramsMap.get(REFRESH_TOKEN));
+        getRedirectStrategy().sendRedirect(request, response, url);
+    }
+
+    private String generateUrlString(Map<String, String> paramsMap) {
+        return UriComponentsBuilder.fromUriString(BASE_URL)
+                .queryParam(ACCESS_TOKEN, paramsMap.get(ACCESS_TOKEN))
+                .queryParam(REFRESH_TOKEN, paramsMap.get(REFRESH_TOKEN))
+                .build()
+                .toUri()
+                .toString();
+    }
+}

--- a/src/main/java/io/powerrangers/backend/config/SecurityConfig.java
+++ b/src/main/java/io/powerrangers/backend/config/SecurityConfig.java
@@ -1,0 +1,44 @@
+package io.powerrangers.backend.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final Oauth2SuccessHandler oauth2SuccessHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(
+                        session -> session.sessionCreationPolicy(
+                                SessionCreationPolicy.STATELESS
+                        )
+                )
+                .oauth2Login(oauth2 -> oauth2.successHandler(oauth2SuccessHandler))
+                .authorizeHttpRequests(auth ->
+                        auth
+                                .requestMatchers("/admin/**")
+                                    .hasAuthority("ADMIN")
+                                .requestMatchers("/test/**")
+                                    .permitAll()
+                                .anyRequest()
+                                    .authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/io/powerrangers/backend/dao/RefreshTokenBlackListRepository.java
+++ b/src/main/java/io/powerrangers/backend/dao/RefreshTokenBlackListRepository.java
@@ -1,0 +1,8 @@
+package io.powerrangers.backend.dao;
+
+import io.powerrangers.backend.entity.RefreshTokenBlackList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenBlackListRepository extends JpaRepository<RefreshTokenBlackList, Long> {
+    boolean existsByRefreshToken_RefreshToken(String refreshToken);
+}

--- a/src/main/java/io/powerrangers/backend/dao/RefreshTokenRepository.java
+++ b/src/main/java/io/powerrangers/backend/dao/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package io.powerrangers.backend.dao;
+
+import io.powerrangers.backend.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/java/io/powerrangers/backend/dao/TokenRepository.java
+++ b/src/main/java/io/powerrangers/backend/dao/TokenRepository.java
@@ -1,0 +1,13 @@
+package io.powerrangers.backend.dao;
+
+import io.powerrangers.backend.entity.RefreshToken;
+import io.powerrangers.backend.entity.RefreshTokenBlackList;
+import io.powerrangers.backend.entity.User;
+import java.util.Optional;
+
+public interface TokenRepository {
+    void save(User user, String refreshToken);
+    boolean isTokenBlackList(String refreshToken);
+    RefreshTokenBlackList addBlackList(RefreshToken refreshToken);
+    Optional<RefreshToken> findValidRefreshToken(Long userId);
+}

--- a/src/main/java/io/powerrangers/backend/dao/TokenRepository.java
+++ b/src/main/java/io/powerrangers/backend/dao/TokenRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface TokenRepository {
     void save(User user, String refreshToken);
-    boolean isTokenBlackList(String refreshToken);
+    boolean tokenBlackList(String refreshToken);
     RefreshTokenBlackList addBlackList(RefreshToken refreshToken);
     Optional<RefreshToken> findValidRefreshToken(Long userId);
 }

--- a/src/main/java/io/powerrangers/backend/dao/UserRepository.java
+++ b/src/main/java/io/powerrangers/backend/dao/UserRepository.java
@@ -1,0 +1,9 @@
+package io.powerrangers.backend.dao;
+
+import io.powerrangers.backend.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/io/powerrangers/backend/dao/adapter/RefreshTokenRepositoryAdapter.java
+++ b/src/main/java/io/powerrangers/backend/dao/adapter/RefreshTokenRepositoryAdapter.java
@@ -1,0 +1,56 @@
+package io.powerrangers.backend.dao.adapter;
+
+import io.powerrangers.backend.dao.RefreshTokenBlackListRepository;
+import io.powerrangers.backend.dao.RefreshTokenRepository;
+import io.powerrangers.backend.dao.TokenRepository;
+import io.powerrangers.backend.entity.RefreshToken;
+import io.powerrangers.backend.entity.RefreshTokenBlackList;
+import io.powerrangers.backend.entity.User;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepositoryAdapter implements TokenRepository {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final RefreshTokenBlackListRepository refreshTokenBlackListRepository;
+    private final EntityManager entityManager;
+
+    @Override
+    @Transactional
+    public void save(User user, String refreshToken) {
+        RefreshToken token = RefreshToken.builder()
+                .user(user)
+                .refreshToken(refreshToken)
+                .build();
+        refreshTokenRepository.save(token);
+    }
+
+    @Override
+    public boolean isTokenBlackList(String refreshToken) {
+        return refreshTokenBlackListRepository.existsByRefreshToken_RefreshToken(refreshToken);
+    }
+
+    @Override
+    @Transactional
+    public RefreshTokenBlackList addBlackList(RefreshToken refreshToken) {
+        RefreshTokenBlackList blackList = RefreshTokenBlackList.builder()
+                .refreshToken(refreshToken)
+                .build();
+        return refreshTokenBlackListRepository.save(blackList);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<RefreshToken> findValidRefreshToken(Long userId) {
+        String jpql =
+                "SELECT rt FROM RefreshToken rt LEFT JOIN RefreshTokenBlackList rtbl ON rt.user.id = :userId AND rtbl.refreshToken IS NULL";
+        return entityManager.createQuery(jpql, RefreshToken.class)
+                .setParameter("userId",userId)
+                .getResultStream()
+                .findFirst();
+    }
+}

--- a/src/main/java/io/powerrangers/backend/dao/adapter/RefreshTokenRepositoryAdapter.java
+++ b/src/main/java/io/powerrangers/backend/dao/adapter/RefreshTokenRepositoryAdapter.java
@@ -30,7 +30,7 @@ public class RefreshTokenRepositoryAdapter implements TokenRepository {
     }
 
     @Override
-    public boolean isTokenBlackList(String refreshToken) {
+    public boolean tokenBlackList(String refreshToken) {
         return refreshTokenBlackListRepository.existsByRefreshToken_RefreshToken(refreshToken);
     }
 

--- a/src/main/java/io/powerrangers/backend/dto/TokenBody.java
+++ b/src/main/java/io/powerrangers/backend/dto/TokenBody.java
@@ -1,11 +1,14 @@
 package io.powerrangers.backend.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class TokenBody {
-    private Long userId;
-    private String role;
+    private final Long userId;
+    private final String role;
 }

--- a/src/main/java/io/powerrangers/backend/dto/TokenBody.java
+++ b/src/main/java/io/powerrangers/backend/dto/TokenBody.java
@@ -1,0 +1,11 @@
+package io.powerrangers.backend.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenBody {
+    private Long userId;
+    private String role;
+}

--- a/src/main/java/io/powerrangers/backend/dto/TokenPair.java
+++ b/src/main/java/io/powerrangers/backend/dto/TokenPair.java
@@ -1,0 +1,11 @@
+package io.powerrangers.backend.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenPair {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/io/powerrangers/backend/dto/TokenPair.java
+++ b/src/main/java/io/powerrangers/backend/dto/TokenPair.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class TokenPair {
-    private String accessToken;
-    private String refreshToken;
+    private final String accessToken;
+    private final String refreshToken;
 }

--- a/src/main/java/io/powerrangers/backend/dto/TokenPair.java
+++ b/src/main/java/io/powerrangers/backend/dto/TokenPair.java
@@ -1,10 +1,12 @@
 package io.powerrangers.backend.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class TokenPair {
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/io/powerrangers/backend/dto/UserDetails.java
+++ b/src/main/java/io/powerrangers/backend/dto/UserDetails.java
@@ -8,19 +8,26 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Accessors(chain = true)
 public class UserDetails implements OAuth2User {
+    @Setter
     private Long id;
+
     private String name;
     private String email;
     private String providerId;
     private String profileImage;
     private Map<String, Object> attributes;
+
+    @Setter
     private Role role;
 
     public static UserDetails from(User user) {
@@ -46,13 +53,5 @@ public class UserDetails implements OAuth2User {
         this.providerId = providerId;
         this.attributes = attributes;
         this.profileImage = profileImage;
-    }
-
-    public void changeId(Long id) {
-        this.id = id;
-    }
-
-    public void changeRole(Role role) {
-        this.role = role;
     }
 }

--- a/src/main/java/io/powerrangers/backend/dto/UserDetails.java
+++ b/src/main/java/io/powerrangers/backend/dto/UserDetails.java
@@ -1,0 +1,58 @@
+package io.powerrangers.backend.dto;
+
+import io.powerrangers.backend.entity.User;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserDetails implements OAuth2User {
+    private Long id;
+    private String name;
+    private String email;
+    private String providerId;
+    private String profileImage;
+    private Map<String, Object> attributes;
+    private Role role;
+
+    public static UserDetails from(User user) {
+        UserDetails details = new UserDetails();
+        details.id = user.getId();
+        details.name = user.getNickname();
+        details.email = user.getEmail();
+        details.role = user.getRole();
+        details.providerId = user.getProviderId();
+        details.profileImage = user.getProfileImage();
+        return details;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role.name()));
+    }
+
+    @Builder
+    public UserDetails(String name, String email, String providerId, Map<String, Object> attributes, String profileImage) {
+        this.name = name;
+        this.email = email;
+        this.providerId = providerId;
+        this.attributes = attributes;
+        this.profileImage = profileImage;
+    }
+
+    public void changeId(Long id) {
+        this.id = id;
+    }
+
+    public void changeRole(Role role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/io/powerrangers/backend/entity/RefreshToken.java
+++ b/src/main/java/io/powerrangers/backend/entity/RefreshToken.java
@@ -1,0 +1,37 @@
+package io.powerrangers.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+    @Id
+    @Column(name = "refresh_token_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private String refreshToken;
+
+    @Builder
+    public RefreshToken(User user, String refreshToken) {
+        this.user = user;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/io/powerrangers/backend/entity/RefreshTokenBlackList.java
+++ b/src/main/java/io/powerrangers/backend/entity/RefreshTokenBlackList.java
@@ -1,0 +1,30 @@
+package io.powerrangers.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshTokenBlackList {
+    @Id
+    @Column(name = "refresh_token__black_list_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    private RefreshToken refreshToken;
+
+    @Builder
+    public RefreshTokenBlackList(RefreshToken refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/io/powerrangers/backend/service/ContextUtil.java
+++ b/src/main/java/io/powerrangers/backend/service/ContextUtil.java
@@ -1,0 +1,21 @@
+package io.powerrangers.backend.service;
+
+import io.powerrangers.backend.dto.UserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class ContextUtil {
+
+    private ContextUtil() {
+    }
+
+    public static Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new RuntimeException("인증된 사용자가 없습니다.");
+        }
+
+        UserDetails principal = (UserDetails) authentication.getPrincipal();
+        return principal.getId();
+    }
+}

--- a/src/main/java/io/powerrangers/backend/service/CustomOauth2UserService.java
+++ b/src/main/java/io/powerrangers/backend/service/CustomOauth2UserService.java
@@ -1,0 +1,56 @@
+package io.powerrangers.backend.service;
+
+import io.powerrangers.backend.dao.UserRepository;
+import io.powerrangers.backend.dto.UserDetails;
+import io.powerrangers.backend.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOauth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    public UserDetails getUserDetails(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new RuntimeException("존재하지 않는 유저입니다."));
+        return UserDetails.from(user);
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String provider = userRequest.getClientRegistration().getRegistrationId(); // google, naver, kakao
+        UserDetails userDetails = UserDetailsFactory.userDetails(oAuth2User, provider);
+
+        User findUser = userRepository.findByEmail(userDetails.getEmail()).orElseGet(
+                () -> {
+                    User user = User.builder()
+                            .nickname(userDetails.getName())
+                            .email(userDetails.getEmail())
+                            .provider(provider)
+                            .providerId(userDetails.getProviderId())
+                            .profileImage(userDetails.getProfileImage())
+                            .build();
+                    return userRepository.save(user);
+                }
+        );
+
+        if (findUser.getProvider().equals(provider)) {
+            userDetails.changeId(findUser.getId());
+            userDetails.changeRole(findUser.getRole());
+            log.info("userDetails = {}", userDetails);
+            return userDetails;
+        } else {
+            throw new OAuth2AuthenticationException("User already registered with another provider.");
+        }
+    }
+}

--- a/src/main/java/io/powerrangers/backend/service/CustomOauth2UserService.java
+++ b/src/main/java/io/powerrangers/backend/service/CustomOauth2UserService.java
@@ -45,10 +45,8 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
         );
 
         if (findUser.getProvider().equals(provider)) {
-            userDetails.changeId(findUser.getId());
-            userDetails.changeRole(findUser.getRole());
             log.info("userDetails = {}", userDetails);
-            return userDetails;
+            return userDetails.setId(findUser.getId()).setRole(findUser.getRole());
         } else {
             throw new OAuth2AuthenticationException("User already registered with another provider.");
         }

--- a/src/main/java/io/powerrangers/backend/service/JwtProvider.java
+++ b/src/main/java/io/powerrangers/backend/service/JwtProvider.java
@@ -63,10 +63,6 @@ public class JwtProvider {
     }
 
     public boolean validateToken(String token) {
-        if(tokenRepository.isTokenBlackList(token)){
-            return false;
-        }
-
         try {
             JwtParser parser = Jwts.parser()
                     .verifyWith(getSecretKey())

--- a/src/main/java/io/powerrangers/backend/service/JwtProvider.java
+++ b/src/main/java/io/powerrangers/backend/service/JwtProvider.java
@@ -1,0 +1,114 @@
+package io.powerrangers.backend.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
+import io.jsonwebtoken.security.Keys;
+import io.powerrangers.backend.dao.TokenRepository;
+import io.powerrangers.backend.dto.Role;
+import io.powerrangers.backend.dto.TokenBody;
+import io.powerrangers.backend.dto.TokenPair;
+import io.powerrangers.backend.entity.RefreshToken;
+import io.powerrangers.backend.entity.User;
+import java.util.Date;
+import java.util.Optional;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtProvider {
+    private final TokenRepository tokenRepository;
+
+    @Value("${custom.jwt.validation.access}")
+    private Long accessTokenExpiration;
+
+    @Value("${custom.jwt.validation.refresh}")
+    private Long refreshTokenExpiration;
+
+    @Value("${custom.jwt.secrets.app-key}")
+    private String jwtSecret;
+
+    public String issueAccessToken(Long id, Role role) {
+        return issueToken(id, role, accessTokenExpiration);
+    }
+
+    public String issueRefreshToken(Long id, Role role) {
+        return issueToken(id, role, refreshTokenExpiration);
+    }
+
+    public TokenPair generateTokenPair(User user) {
+        Long id = user.getId();
+        Role role = user.getRole();
+        String accessToken = issueAccessToken(id,role);
+        String refreshToken = issueRefreshToken(id,role);
+
+        tokenRepository.save(user, refreshToken);
+
+        return TokenPair.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public Optional<RefreshToken> findValidRefreshToken(Long userId) {
+        return tokenRepository.findValidRefreshToken(userId);
+    }
+
+    public boolean validateToken(String token) {
+        if(tokenRepository.isTokenBlackList(token)){
+            return false;
+        }
+
+        try {
+            JwtParser parser = Jwts.parser()
+                    .verifyWith(getSecretKey())
+                    .build();
+            parser.parseSignedClaims(token);
+            return true;
+        } catch (JwtException e) {
+            log.error("유효하지 않은 토큰입니다");
+        } catch (IllegalStateException e) {
+            log.error("이상한 토큰입니다");
+        } catch (Exception e) {
+            log.error("완전히 이상한 토큰입니다.");
+        }
+        return false;
+    }
+
+    public TokenBody parseToken(String token) {
+        JwtParser parser = Jwts.parser()
+                .verifyWith(getSecretKey())
+                .build();
+        Jws<Claims> claimsJws = parser.parseSignedClaims(token);
+
+        String sub = claimsJws.getPayload().getSubject();
+        String role = (String) claimsJws.getPayload().get("role");
+
+        return TokenBody.builder()
+                .userId(Long.valueOf(sub))
+                .role(role)
+                .build();
+    }
+
+    private String issueToken(Long id, Role role, Long expiration) {
+        return Jwts.builder()
+                .subject(id.toString())
+                .claim("role", role.name())
+                .issuedAt(new Date())
+                .expiration(new Date(new Date().getTime() + expiration))
+                .signWith(getSecretKey(), SIG.HS256)
+                .compact();
+    }
+
+    private SecretKey getSecretKey() {
+        return Keys.hmacShaKeyFor(jwtSecret.getBytes());
+    }
+}

--- a/src/main/java/io/powerrangers/backend/service/UserDetailsFactory.java
+++ b/src/main/java/io/powerrangers/backend/service/UserDetailsFactory.java
@@ -1,0 +1,23 @@
+package io.powerrangers.backend.service;
+
+import io.powerrangers.backend.dto.UserDetails;
+import java.util.Map;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public class UserDetailsFactory {
+    public static UserDetails userDetails(OAuth2User oAuth2User, String providerId) {
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        switch (providerId.toLowerCase()) {
+            case "google" -> {
+                return UserDetails.builder()
+                        .name(attributes.get("name").toString())
+                        .email(attributes.get("email").toString())
+                        .providerId(attributes.get("sub").toString())
+                        .profileImage(attributes.get("picture").toString())
+                        .attributes(attributes)
+                        .build();
+            }
+            default -> throw new IllegalArgumentException("Unsupported provider: " + providerId);
+        }
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#5 

## 🪐 작업 내용
- Spring Security 를 적용했습니다. 알아두셔야 할 사항은 크게 다음과 같습니다.
### 1. JwtAuthenticationFilter
여기서는 클라이언트의 요청의 헤더에서 토큰을 꺼내 유효성을 확인합니다. 유효하지 않다면 `RuntimeException`을 발생시킵니다. 만약 나중에 **JWT 검증을 하지 않아야 하는 URL이 있다면 아래의 WHITE_LIST에 추가**해야 합니다.
```java
private final List<String> WHITE_LIST = List.of(
            "/test/**"
);

@Override
protected boolean shouldNotFilter(HttpServletRequest request) {
      String path = request.getRequestURI();
      return WHITE_LIST.stream()
                .anyMatch(pattern -> antPathMatcher.match(pattern, path));
}
```
- 위 `shouldNotFilter` 을 사용하여 WHITE_LIST 내에 존재하는 URL은 필터를 그대로 통과시킵니다. `antPathMatcher` 을 사용했기 때문에 정규표현식을 사용할 수 있습니다.

### 2. Spring Security
```java
.authorizeHttpRequests(auth ->
              auth
                      .requestMatchers("/admin/**")
                          .hasAuthority("ADMIN")
                      .requestMatchers("/test/**")
                          .permitAll()
                      .anyRequest()
                          .authenticated()
)
```
- 혹시 권한 관련 설정이 필요하시다면 여기서 추가해주시면 됩니다. 여기에 어떤 URL이 들어갈지는 다 같이 생각해보면 좋을 듯 합니다.
### 3. 기타 Security 설정
- 최대한 이해를 쉽게 하기 위해 강의에서 사용한 실습 코드를 이용하고자 하였습니다. `UserDetails` 부분만 추가 필드가 있고, 나머지는 거의 비슷합니다.
- 현재는 구글 로그인만 되어있는 상태입니다. 그리고 현재는 로그인을 해도 재로그인을 하도록 화면이 리다이렉션이 되는데, **access token과 refresh token이 콘솔에 출력되도록 로그를 찍어놨으니 여기서 토큰을 복사해서 postman 으로 테스트 하시면 정상 작동**합니다. 
(저는 아래와 같이 더미 컨트롤러를 만들어서 "/user" 가 붙은 요청은 `authenticated()` 하게 설정하고 테스트했는데, 정상적으로 동작하더라고요)
```java
@RestController
public class TestController {
    @GetMapping("/user")
    public String user() {
        return "Hello User!";
    }
}
```
- 참고로 헤더에 담으실때는 헤더에 Authorization 타입으로 **"Bearer {access-token}"** 형식으로 보내셔야 합니다! (Bearer 와 access token 사이에 띄어쓰기 있음)

### 4. Refresh Token 재발급 로직
- Access Token이 만료되면 재로그인을 하는게 아니라 "/token/refresh" 같은 URL 로 POST 요청을 Refresh Token와 같이 보내서 유효한 Refresh Token이라면 Access Token을 재발급하는 방식을 사용하려고 합니다.
- **아직 관련 컨트롤러가 없어서 User 관련 로직과 merge 되면 추가하도록 하겠습니다!**

### 5. `ContextUtil`
- SecurityContext 내에 존재하는 Authentication 객체에서 요청을 보낸 user의 id를 추출하는 메서드를 구현했습니다.
- 별도의 서비스로 만들까 생각하다가 따로 상태 관리가 필요없고, 많은 곳에서 `ContextUtil` 을 사용할 것으로 예상되어 유틸리티 클래스로 만들어 봤습니다. 
- 다른 클래스에서 사용할 때는 별도의 의존성 주입 없이 static 메서드로 아래와 같이 사용 가능 합니다.
```java
Long currentUserId = ContextUtil.getCurrentUserId();
```

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?