### PR TITLE
Feat: 로그인하면 index로 이동하고, 각 토큰이 local storage에 저장되도록 변경

### DIFF
--- a/src/main/java/io/powerrangers/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/io/powerrangers/backend/config/JwtAuthenticationFilter.java
@@ -65,7 +65,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("authorization");
+        String bearerToken = request.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }

--- a/src/main/java/io/powerrangers/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/io/powerrangers/backend/config/JwtAuthenticationFilter.java
@@ -29,12 +29,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
 
     private final List<String> WHITE_LIST = List.of(
-            "/test/**"
+            "/test/**",
+            "/favicon.ico",
+            "/index.html",
+            "/css/**",
+            "/js/**"
     );
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-
+        log.error("filter에서 문제 발생! uri = {}", request.getRequestURI());
         String token = resolveToken(request);
         if (token != null && jwtProvider.validateToken(token)) {
             TokenBody tokenBody = jwtProvider.parseToken(token);

--- a/src/main/java/io/powerrangers/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/io/powerrangers/backend/config/JwtAuthenticationFilter.java
@@ -38,7 +38,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        log.error("filter에서 문제 발생! uri = {}", request.getRequestURI());
         String token = resolveToken(request);
         if (token != null && jwtProvider.validateToken(token)) {
             TokenBody tokenBody = jwtProvider.parseToken(token);

--- a/src/main/java/io/powerrangers/backend/config/Oauth2SuccessHandler.java
+++ b/src/main/java/io/powerrangers/backend/config/Oauth2SuccessHandler.java
@@ -31,7 +31,7 @@ public class Oauth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final JwtProvider jwtProvider;
     private static final String ACCESS_TOKEN = "accessToken";
     private static final String REFRESH_TOKEN = "refreshToken";
-    private static final String BASE_URL = "http://localhost:8080/user";
+    private static final String BASE_URL = "http://localhost:8080/index.html";
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/java/io/powerrangers/backend/config/SecurityConfig.java
+++ b/src/main/java/io/powerrangers/backend/config/SecurityConfig.java
@@ -33,7 +33,11 @@ public class SecurityConfig {
                         auth
                                 .requestMatchers("/admin/**")
                                     .hasAuthority("ADMIN")
-                                .requestMatchers("/test/**")
+                                .requestMatchers("/test/**",
+                                        "/index.html",
+                                        "/favicon.ico",
+                                        "/css/**",
+                                        "/js/**")
                                     .permitAll()
                                 .anyRequest()
                                     .authenticated()

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>홈 페이지</title>
+    <script>
+        window.onload = async () => {
+            const urlParams = new URLSearchParams(window.location.search);
+            const accessToken = urlParams.get('accessToken');
+            const refreshToken = urlParams.get('refreshToken');
+
+            if (!accessToken) {
+                document.body.innerHTML = "<p>사용자 인증 정보가 없습니다.</p>";
+                return;
+            }
+
+            localStorage.setItem('accessToken', accessToken);
+            localStorage.setItem('refreshToken', refreshToken);
+        };
+    </script>
+</head>
+<body>
+    로그인 성공!
+</body>
+</html>


### PR DESCRIPTION
## 🛰️ Issue Number
- #20 

## 🪐 작업 내용
- 로그인을 하면 index.html 페이지로 이동하게 구현했습니다.
- index.html 페이지에 이동할 때 인증, 인가 과정을 거치지 않게 Filter, Config 파일에 URL 을 추가하였습니다.
- 기타 favicon, css, js 파일들이 추가된다면 이것들도 인증, 인가 과정을 거치지 않아야 해서 이것도 추가하였습니다.
```java
public class JwtAuthenticationFilter extends OncePerRequestFilter {
    private final JwtProvider jwtProvider;
    private final CustomOauth2UserService customOauth2UserService;
    private final AntPathMatcher antPathMatcher = new AntPathMatcher();

    private final List<String> WHITE_LIST = List.of(
            "/test/**",
            "/favicon.ico",
            "/index.html",
            "/css/**",
            "/js/**"
    );
```

```java
.requestMatchers("/test/**",
                            "/index.html",
                            "/favicon.ico",
                            "/css/**",
                            "/js/**")
                        .permitAll()
```
- 로그인에 성공하면 화면에 "로그인 성공!" 이 뜨게 되고, 쿼리 파라미터로 access token, refresh token이 날라옵니다. 이 토큰들은 local storage에 잘 저장됩니다.
![image](https://github.com/user-attachments/assets/130bc3f3-52fe-4719-b4e7-c66b4a85630f)
![image](https://github.com/user-attachments/assets/0ddbf524-a505-4311-b0e2-d2d631ee93c3)

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?