### PR TITLE
Feat : 팔로잉 목록 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,15 +25,15 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    //implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    //implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    //testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // JWT

--- a/src/main/java/io/powerrangers/backend/controller/FollowController.java
+++ b/src/main/java/io/powerrangers/backend/controller/FollowController.java
@@ -41,4 +41,10 @@ public class FollowController {
 
         return ResponseEntity.ok(followService.findFollowers(userId));
     }
+
+    @GetMapping("/{userId}/followings")
+    public ResponseEntity<List<UserFollowResponseDto>> getFollowings(@PathVariable Long userId){
+        return ResponseEntity.ok(followService.findFollowings(userId));
+    }
+
 }

--- a/src/main/java/io/powerrangers/backend/dao/FollowRepository.java
+++ b/src/main/java/io/powerrangers/backend/dao/FollowRepository.java
@@ -14,4 +14,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     @Query("select new io.powerrangers.backend.dto.UserFollowResponseDto(u.id, u.nickname, u.intro, u.profileImage) from Follow f JOIN f.follower u where f.following.id = :userId")
     List<UserFollowResponseDto> findFollowersByUser(Long userId);
+
+    @Query("select new io.powerrangers.backend.dto.UserFollowResponseDto(u.id, u.nickname, u.intro, u.profileImage) from Follow f JOIN f.following u where f.follower.id = :userId")
+    List<UserFollowResponseDto> findFollowingsByUser(Long userId);
 }

--- a/src/main/java/io/powerrangers/backend/service/FollowService.java
+++ b/src/main/java/io/powerrangers/backend/service/FollowService.java
@@ -78,10 +78,15 @@ public class FollowService {
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 사용자입니다."));
 
         // 팔로잉에 userId가 있어야 한다.
-        List<UserFollowResponseDto> followers = followRepository.findFollowersByUser(userId);
-
-        return followers;
+        return followRepository.findFollowersByUser(userId);
     }
 
+    @Transactional(readOnly=true)
+    public List<UserFollowResponseDto> findFollowings(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 사용자입니다."));
 
+        // 팔로워 id에 userId가 있어야 한다.
+        return followRepository.findFollowingsByUser(userId);
+    }
 }

--- a/src/main/java/io/powerrangers/backend/service/TaskService.java
+++ b/src/main/java/io/powerrangers/backend/service/TaskService.java
@@ -1,5 +1,6 @@
 package io.powerrangers.backend.service;
 
+import io.powerrangers.backend.dao.UserRepository;
 import io.powerrangers.backend.dto.*;
 import io.powerrangers.backend.entity.Task;
 import io.powerrangers.backend.entity.User;

--- a/src/test/java/io/powerrangers/backend/service/FollowServiceTests.java
+++ b/src/test/java/io/powerrangers/backend/service/FollowServiceTests.java
@@ -180,4 +180,39 @@ class FollowServiceTests {
 
     }
 
+    @Test
+    @DisplayName("팔로잉 목록 조회 테스트")
+    void following_list_test() throws Exception {
+
+        Long myId = 1L;
+        User me = mock(User.class);
+        when(userRepository.findById(myId)).thenReturn(Optional.of(me));
+
+        UserFollowResponseDto following_1 = UserFollowResponseDto.builder()
+                .id(2L)
+                .nickname("user_2")
+                .intro("안녕하세요. 유저 2입니다.")
+                .profileImage("img2")
+                .build();
+
+        UserFollowResponseDto following_2 = UserFollowResponseDto.builder()
+                .id(3L)
+                .nickname("user_3")
+                .intro("안녕하세요. 유저 3입니다.")
+                .profileImage("img3")
+                .build();
+
+        List<UserFollowResponseDto> followingsOfMine = List.of(following_1, following_2);
+
+        when(followRepository.findFollowingsByUser(myId)).thenReturn(followingsOfMine);
+
+        List<UserFollowResponseDto> followings = followService.findFollowings(myId);
+
+        assertThat(followings).hasSize(2);
+        assertThat(followings.get(0)).isEqualTo(following_1);
+        assertThat(followings.get(1)).isEqualTo(following_2);
+
+
+    }
+
 }

--- a/src/test/java/io/powerrangers/backend/service/TaskServiceTest.java
+++ b/src/test/java/io/powerrangers/backend/service/TaskServiceTest.java
@@ -1,5 +1,6 @@
 package io.powerrangers.backend.service;
 
+import io.powerrangers.backend.dao.UserRepository;
 import io.powerrangers.backend.dto.*;
 import io.powerrangers.backend.entity.Task;
 import io.powerrangers.backend.entity.User;


### PR DESCRIPTION
## 🛰️ Issue Number
- #24 

## 🪐 작업 내용
- FollowController에 팔로잉 목록 조회 api 구현 완료
- FollowService에 findFollowings 메서드 구현 완료
- FollowRepository에서 `@Query`로 유저가 팔로잉하고 있는 목록을 List에 담아서 반환
- 테스트 코드 작성 완료
- 포스트맨으로 테스트 완료

## 📚 Reference


## ✅ Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] 포스트맨으로 테스트 했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?