### PR TITLE
Feat: 댓글 수정 기능 구현

### DIFF
--- a/src/main/java/io/powerrangers/backend/controller/CommentController.java
+++ b/src/main/java/io/powerrangers/backend/controller/CommentController.java
@@ -1,7 +1,9 @@
 package io.powerrangers.backend.controller;
 
+import io.powerrangers.backend.dao.CommentRepository;
 import io.powerrangers.backend.dto.comment.CommentCreateRequestDto;
 import io.powerrangers.backend.dto.comment.CommentResponseDto;
+import io.powerrangers.backend.dto.comment.CommentUpdateRequestDto;
 import io.powerrangers.backend.service.CommentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +34,12 @@ public class CommentController {
     public ResponseEntity<List<CommentResponseDto>> getComments(@PathVariable Long taskId){
         List<CommentResponseDto> comments = commentService.getComments(taskId);
         return ResponseEntity.ok(comments);
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<Void> updateComment(@PathVariable Long commentId,
+                                              @Valid @RequestBody CommentUpdateRequestDto request){
+        commentService.updateComment(commentId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/io/powerrangers/backend/controller/CommentController.java
+++ b/src/main/java/io/powerrangers/backend/controller/CommentController.java
@@ -4,6 +4,7 @@ import io.powerrangers.backend.dao.CommentRepository;
 import io.powerrangers.backend.dto.comment.CommentCreateRequestDto;
 import io.powerrangers.backend.dto.comment.CommentResponseDto;
 import io.powerrangers.backend.dto.comment.CommentUpdateRequestDto;
+import io.powerrangers.backend.dto.comment.CommentUpdateResponseDto;
 import io.powerrangers.backend.service.CommentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,9 +38,9 @@ public class CommentController {
     }
 
     @PutMapping("/{commentId}")
-    public ResponseEntity<Void> updateComment(@PathVariable Long commentId,
+    public ResponseEntity<CommentUpdateResponseDto> updateComment(@PathVariable Long commentId,
                                               @Valid @RequestBody CommentUpdateRequestDto request){
-        commentService.updateComment(commentId, request);
-        return ResponseEntity.noContent().build();
+        CommentUpdateResponseDto response = commentService.updateComment(commentId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/io/powerrangers/backend/dto/comment/CommentUpdateRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/comment/CommentUpdateRequestDto.java
@@ -1,0 +1,15 @@
+package io.powerrangers.backend.dto.comment;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CommentUpdateRequestDto {
+    @NotBlank(message="내용을 입력해주세요.")
+    private final String content;
+}

--- a/src/main/java/io/powerrangers/backend/dto/comment/CommentUpdateResponseDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/comment/CommentUpdateResponseDto.java
@@ -1,0 +1,23 @@
+package io.powerrangers.backend.dto.comment;
+
+import io.powerrangers.backend.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CommentUpdateResponseDto {
+    private final Long id;
+    private final String content;
+    private final String nickname;
+
+    public static CommentUpdateResponseDto from(Comment comment) {
+        return CommentUpdateResponseDto.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .nickname(comment.getUser().getNickname())
+                .build();
+    }
+}

--- a/src/main/java/io/powerrangers/backend/entity/Comment.java
+++ b/src/main/java/io/powerrangers/backend/entity/Comment.java
@@ -48,4 +48,13 @@ public class Comment extends BaseEntity {
         this.parent = parent;
         this.content = content;
     }
+
+    public void updateContent(String content){
+        this.content = content;
+    }
+
+    //추후 토큰 연관해서 변경예정
+    public boolean Authored(Long userId){
+        return this.user.getId().equals(userId);
+    }
 }

--- a/src/main/java/io/powerrangers/backend/service/CommentService.java
+++ b/src/main/java/io/powerrangers/backend/service/CommentService.java
@@ -4,6 +4,7 @@ import io.powerrangers.backend.dao.TaskRepository;
 import io.powerrangers.backend.dao.UserRepository;
 import io.powerrangers.backend.dto.comment.CommentCreateRequestDto;
 import io.powerrangers.backend.dto.comment.CommentResponseDto;
+import io.powerrangers.backend.dto.comment.CommentUpdateRequestDto;
 import io.powerrangers.backend.entity.Comment;
 import io.powerrangers.backend.entity.Task;
 import io.powerrangers.backend.entity.User;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -63,6 +65,16 @@ public class CommentService {
                 .map(parent -> toDto(parent, allComments))
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public void updateComment(Long commentid, CommentUpdateRequestDto request) throws NoSuchElementException {
+        Comment comment = commentRepository.findById(commentid)
+                .orElseThrow(()-> new NoSuchElementException("댓글이 없습니다.."));
+
+        //작성자 검증기능 추후에 구현 해야함
+        comment.updateContent(request.getContent());
+    }
+
 
     private CommentResponseDto toDto(Comment parent, List<Comment> allComments) {
         List<CommentResponseDto> childrenDtos = allComments.stream()

--- a/src/main/java/io/powerrangers/backend/service/CommentService.java
+++ b/src/main/java/io/powerrangers/backend/service/CommentService.java
@@ -5,6 +5,7 @@ import io.powerrangers.backend.dao.UserRepository;
 import io.powerrangers.backend.dto.comment.CommentCreateRequestDto;
 import io.powerrangers.backend.dto.comment.CommentResponseDto;
 import io.powerrangers.backend.dto.comment.CommentUpdateRequestDto;
+import io.powerrangers.backend.dto.comment.CommentUpdateResponseDto;
 import io.powerrangers.backend.entity.Comment;
 import io.powerrangers.backend.entity.Task;
 import io.powerrangers.backend.entity.User;
@@ -67,12 +68,14 @@ public class CommentService {
     }
 
     @Transactional
-    public void updateComment(Long commentid, CommentUpdateRequestDto request) throws NoSuchElementException {
+    public CommentUpdateResponseDto updateComment(Long commentid, CommentUpdateRequestDto request) throws NoSuchElementException {
         Comment comment = commentRepository.findById(commentid)
                 .orElseThrow(()-> new NoSuchElementException("댓글이 없습니다.."));
 
         //작성자 검증기능 추후에 구현 해야함
         comment.updateContent(request.getContent());
+
+        return CommentUpdateResponseDto.from(comment);
     }
 
 

--- a/src/test/java/io/powerrangers/backend/service/CommentServiceTests.java
+++ b/src/test/java/io/powerrangers/backend/service/CommentServiceTests.java
@@ -4,6 +4,7 @@ import io.powerrangers.backend.dto.TaskScope;
 import io.powerrangers.backend.dto.TaskStatus;
 import io.powerrangers.backend.dto.comment.CommentCreateRequestDto;
 import io.powerrangers.backend.dto.comment.CommentResponseDto;
+import io.powerrangers.backend.dto.comment.CommentUpdateRequestDto;
 import io.powerrangers.backend.entity.Comment;
 import io.powerrangers.backend.entity.Task;
 import io.powerrangers.backend.entity.User;
@@ -162,5 +163,34 @@ public class CommentServiceTests {
         assertThat(parentDto.getChildren())
                 .extracting(CommentResponseDto::getContent)
                 .containsExactlyInAnyOrder("대댓글입니다", "불라불라");
+    }
+
+    @Test
+    @DisplayName("댓글 수정 테스트")
+    void 댓글수정() {
+        Comment parent = new Comment(testTask, testUser, null, "부모댓글");
+        commentRepository.save(parent);
+        Comment child1 = new Comment(testTask, testUser, parent, "자식댓글");
+        commentRepository.save(child1);
+
+        String newContent="아싸 수정됐다.";
+        CommentUpdateRequestDto dto = CommentUpdateRequestDto.builder()
+                .content(newContent)
+                .build();
+        commentService.updateComment(parent.getId(),dto);
+
+        Comment updatedParent = commentRepository.findById(parent.getId())
+                .orElseThrow(() -> new RuntimeException("댓글 수정 실패"));
+
+        assertThat(updatedParent.getContent()).isEqualTo(newContent);
+    }
+
+    @Test
+    @DisplayName("댓글 수정 본인 댓글이 아닌경우")
+    void 댓글수정2(){
+        /*
+        * TODO: 사용자 검증으로 본인의 댓글인지 판단하고 예외를 터트리는 테스트를 만들자 (아직 기능 미구현)
+        *
+        * */
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#22 

## 🪐 작업 내용
commentId를 Pathvariable로 받고 수정내용을 requestbody로 받아 댓글 수정하는 기능을 구현하였습니다.
jwt토큰 기반으로 본인의 댓글인지 검증하는 과정을 구현 안해두었는데, 삭제까지 마저 구현 후 댓글 도메인에서 userId 관련된 부분들을 따로 모아
리팩토링 할 예정입니다  

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] 포스트맨 테스트 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?