### PR TITLE
Feat: 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,15 +25,15 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    //implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    //implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    //testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // JWT

--- a/src/main/java/io/powerrangers/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/io/powerrangers/backend/config/JwtAuthenticationFilter.java
@@ -29,12 +29,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
 
     private final List<String> WHITE_LIST = List.of(
-            "/test/**",
-            "/favicon.ico",
-            "/index.html",
-            "/css/**",
-            "/js/**"
+            "/",                  // 루트 요청 (홈 화면)
+            "/test/**",           // 테스트용 API
+            "/favicon.ico",       // 즐겨찾기 아이콘
+            "/index.html",        // 정적 index
+            "/css/**",            // 정적 CSS
+            "/default-ui.css",
+            "/js/**",             // 정적 JS
+            "/webjars/**",        // 의존성 리소스(js 라이브러리 등)
+            "/error",             // 에러 페이지 (Spring 내부에서 요청)
+            "/login",             // 로그인 페이지
+            "/oauth2/**",         // OAuth2 관련 리디렉션 URL
+            "/.well-known/appspecific/com.chrome.devtools.json" // 크롬에서 날라오는 백엔드용 요청..?
     );
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {

--- a/src/main/java/io/powerrangers/backend/config/SecurityConfig.java
+++ b/src/main/java/io/powerrangers/backend/config/SecurityConfig.java
@@ -4,12 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/io/powerrangers/backend/service/UserDetailsFactory.java
+++ b/src/main/java/io/powerrangers/backend/service/UserDetailsFactory.java
@@ -4,6 +4,7 @@ import io.powerrangers.backend.dto.UserDetails;
 import java.util.Map;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+@SuppressWarnings("unchecked")
 public class UserDetailsFactory {
     public static UserDetails userDetails(OAuth2User oAuth2User, String providerId) {
         Map<String, Object> attributes = oAuth2User.getAttributes();
@@ -14,6 +15,16 @@ public class UserDetailsFactory {
                         .email(attributes.get("email").toString())
                         .providerId(attributes.get("sub").toString())
                         .profileImage(attributes.get("picture").toString())
+                        .attributes(attributes)
+                        .build();
+            }
+            case "kakao" -> {
+                Map<String, String> properties = (Map<String, String>) attributes.get("properties");
+                return UserDetails.builder()
+                        .name(properties.get("nickname"))
+                        .email(attributes.get("id").toString() + "@kakao.com")
+                        .providerId(attributes.get("id").toString())
+                        .profileImage(properties.get("profile_image"))
                         .attributes(attributes)
                         .build();
             }

--- a/src/test/java/io/powerrangers/backend/config/AuthTestController.java
+++ b/src/test/java/io/powerrangers/backend/config/AuthTestController.java
@@ -1,18 +1,16 @@
 package io.powerrangers.backend.config;
 
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/test")
 public class AuthTestController {
     @GetMapping("/security-endpoint")
     public String securityEndpoint() {
         return "This is a security endpoint!";
     }
 
-    @GetMapping("/url")
+    @GetMapping("/test/url")
     public String testUrl() {
         return "This is a public endpoint";
     }

--- a/src/test/java/io/powerrangers/backend/config/AuthTestController.java
+++ b/src/test/java/io/powerrangers/backend/config/AuthTestController.java
@@ -1,0 +1,19 @@
+package io.powerrangers.backend.config;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test")
+public class AuthTestController {
+    @GetMapping("/security-endpoint")
+    public String securityEndpoint() {
+        return "This is a security endpoint!";
+    }
+
+    @GetMapping("/url")
+    public String testUrl() {
+        return "This is a public endpoint";
+    }
+}

--- a/src/test/java/io/powerrangers/backend/config/JwtAuthenticationFilterTest.java
+++ b/src/test/java/io/powerrangers/backend/config/JwtAuthenticationFilterTest.java
@@ -1,7 +1,10 @@
 package io.powerrangers.backend.config;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.powerrangers.backend.dto.Role;
@@ -57,8 +60,33 @@ class JwtAuthenticationFilterTest {
         when(jwtProvider.parseToken(token)).thenReturn(tokenBody);
         when(oauth2UserService.getUserDetails(tokenBody.getUserId())).thenReturn(userDetails);
 
-        mockMvc.perform(get("/test/security-endpoint")
+        mockMvc.perform(get("/test/url")
                         .header("Authorization", "Bearer validToken"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("잘못된 토큰으로 필터에서 RuntimeException 발생 검증")
+    void shouldThrowRuntimeExceptionForInvalidToken() {
+        String token = "invalid token";
+        when(jwtProvider.validateToken(token)).thenReturn(false);
+
+        assertThatThrownBy(() ->
+                mockMvc.perform(get("/security-endpoint") // 인증 필요한 경로
+                        .header("Authorization", "Bearer " + token))
+        )
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("문제가 있는 토큰입니다.");
+    }
+
+    @Test
+    @DisplayName("토큰이 없어 필터에서 RuntimeException 발생 검증")
+    void shouldThrowRuntimeExceptionForNullToken() throws Exception {
+        assertThatThrownBy(() ->
+                mockMvc.perform(get("/security-endpoint") // 인증 필요한 경로
+                )
+        )
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("문제가 있는 토큰입니다.");
     }
 }

--- a/src/test/java/io/powerrangers/backend/config/JwtAuthenticationFilterTest.java
+++ b/src/test/java/io/powerrangers/backend/config/JwtAuthenticationFilterTest.java
@@ -1,0 +1,64 @@
+package io.powerrangers.backend.config;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.powerrangers.backend.dto.Role;
+import io.powerrangers.backend.dto.TokenBody;
+import io.powerrangers.backend.dto.UserDetails;
+import io.powerrangers.backend.service.CustomOauth2UserService;
+import io.powerrangers.backend.service.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AuthTestController.class)
+@ExtendWith(MockitoExtension.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+@MockitoBean(types = JpaMetamodelMappingContext.class)
+class JwtAuthenticationFilterTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    JwtProvider jwtProvider;
+
+    @MockitoBean
+    CustomOauth2UserService oauth2UserService;
+
+    @MockitoBean
+    Oauth2SuccessHandler oauth2SuccessHandler;
+
+    @Test
+    @DisplayName("필터 내 토큰 검증 성공")
+    void testValidToken() throws Exception {
+        String token = "valid token";
+        UserDetails userDetails = UserDetails.builder()
+                .name("name")
+                .email("email")
+                .providerId("kakao")
+                .profileImage("profile")
+                .attributes(null)
+                .build();
+        TokenBody tokenBody = TokenBody.builder()
+                .userId(-1L)
+                .role(Role.USER.name())
+                .build();
+        when(jwtProvider.validateToken(token)).thenReturn(true);
+        when(jwtProvider.parseToken(token)).thenReturn(tokenBody);
+        when(oauth2UserService.getUserDetails(tokenBody.getUserId())).thenReturn(userDetails);
+
+        mockMvc.perform(get("/test/security-endpoint")
+                        .header("Authorization", "Bearer validToken"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/io/powerrangers/backend/config/Oauth2SuccessHandlerTest.java
+++ b/src/test/java/io/powerrangers/backend/config/Oauth2SuccessHandlerTest.java
@@ -1,0 +1,80 @@
+package io.powerrangers.backend.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.powerrangers.backend.dao.UserRepository;
+import io.powerrangers.backend.dto.TokenPair;
+import io.powerrangers.backend.dto.UserDetails;
+import io.powerrangers.backend.entity.RefreshToken;
+import io.powerrangers.backend.entity.User;
+import io.powerrangers.backend.service.JwtProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.RedirectStrategy;
+
+@ExtendWith(MockitoExtension.class)
+class Oauth2SuccessHandlerTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private UserDetails userDetails;
+
+    @Mock
+    private RefreshToken refreshToken;
+
+    @InjectMocks
+    private Oauth2SuccessHandler oauth2SuccessHandler;
+
+    @Test
+    void onAuthenticationSuccess_WithoutExistingRefreshToken_ShouldGenerateNewTokensAndRedirect() throws Exception {
+        // given
+        Long userId = 1L;
+        TokenPair tokenPair = new TokenPair("access-token", "refresh-token");
+        User user = User.builder().build();
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        when(userDetails.getId()).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(jwtProvider.findValidRefreshToken(userId)).thenReturn(Optional.empty());
+        when(jwtProvider.generateTokenPair(user)).thenReturn(tokenPair);
+
+        // redirect 전략을 별도로 세팅
+        RedirectStrategy mockRedirectStrategy = mock(RedirectStrategy.class);
+        oauth2SuccessHandler.setRedirectStrategy(mockRedirectStrategy);
+
+        // when
+        oauth2SuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+        // then
+        verify(mockRedirectStrategy).sendRedirect(
+                eq(request),
+                eq(response),
+                argThat(url -> url.contains("accessToken=access-token") && url.contains("refreshToken=refresh-token"))
+        );
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#26 

## 🪐 작업 내용
### 카카오 로그인
- 카카오 로그인을 구현하였습니다. 카카오id (카카오 인증 서버의 고유한 uuid), 이메일, 프로필 사진을 가져옵니다.
- 메인 화면에 처음 들어가면 구글, 카카오 로그인을 선택할 수 있고, 로그인을 하게 되면 index.html로 이동합니다.
![image](https://github.com/user-attachments/assets/1ee744f3-e3e2-4505-b4dd-3b4b18c35577)

### JwtFilter 부분
- 기본적으로 security 에서 제공하는 로그인 페이지의 css, login 페이지 등의 정적인 자원들이 Filter에 걸려 적용되지 않거나 무한 리다이렉트 되는 문제가 있었는데, 이를 모두 `WHITE_LIST` 에 추가하여 Filter 에 거치지 않도록 했습니다.
### application.yml
카카오 로그인이 추가됨에 따라 카카오 로그인 관련 설정들을 작성해야 합니다. 이는 slack에 공유해드릴게요.
### JwtFilter Test
- 짬내서 테스트 코드까지 작성해보았습니다.
- 테스트에서 사용할 TestAuthController 를 만들고 해당 컨트롤러에 요청을 보낼 때 토큰 검증이 잘 되는지 검증하였습니다.
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?