### PR TITLE
Feat : 응답 및 예외 처리 커스텀마이징

### DIFF
--- a/src/main/java/io/powerrangers/backend/config/Oauth2SuccessHandler.java
+++ b/src/main/java/io/powerrangers/backend/config/Oauth2SuccessHandler.java
@@ -5,6 +5,8 @@ import io.powerrangers.backend.dto.TokenPair;
 import io.powerrangers.backend.dto.UserDetails;
 import io.powerrangers.backend.entity.RefreshToken;
 import io.powerrangers.backend.entity.User;
+import io.powerrangers.backend.exception.CustomException;
+import io.powerrangers.backend.exception.ErrorCode;
 import io.powerrangers.backend.service.JwtProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -38,7 +40,7 @@ public class Oauth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                                         Authentication authentication) throws IOException, ServletException {
         UserDetails principal = (UserDetails) authentication.getPrincipal();
         User findUser = userRepository.findById(principal.getId()).orElseThrow(
-                () -> new RuntimeException("존재하지 않는 유저입니다."));
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         HashMap<String, String> paramsMap = new HashMap<>();
         Optional<RefreshToken> validRefreshToken = jwtProvider.findValidRefreshToken(principal.getId());

--- a/src/main/java/io/powerrangers/backend/controller/CommentController.java
+++ b/src/main/java/io/powerrangers/backend/controller/CommentController.java
@@ -27,12 +27,12 @@ public class CommentController {
     @PostMapping
     public ResponseEntity<BaseResponse<?>> createComment(@Valid @RequestBody CommentCreateRequestDto request){
         commentService.createComment(request.getUserId(),request);
-        return BaseResponse.ok(SuccessCode.ADDED_SUCCESS);
+        return BaseResponse.success(SuccessCode.ADDED_SUCCESS);
     }
 
     @GetMapping("/{taskId}")
     public ResponseEntity<BaseResponse<List<CommentResponseDto>>> getComments(@PathVariable Long taskId){
         List<CommentResponseDto> comments = commentService.getComments(taskId);
-        return BaseResponse.ok(SuccessCode.GET_SUCCESS, comments);
+        return BaseResponse.success(SuccessCode.GET_SUCCESS, comments);
     }
 }

--- a/src/main/java/io/powerrangers/backend/controller/CommentController.java
+++ b/src/main/java/io/powerrangers/backend/controller/CommentController.java
@@ -1,5 +1,7 @@
 package io.powerrangers.backend.controller;
 
+import io.powerrangers.backend.dto.BaseResponse;
+import io.powerrangers.backend.dto.SuccessCode;
 import io.powerrangers.backend.dto.comment.CommentCreateRequestDto;
 import io.powerrangers.backend.dto.comment.CommentResponseDto;
 import io.powerrangers.backend.service.CommentService;
@@ -23,14 +25,14 @@ public class CommentController {
      * @return
      */
     @PostMapping
-    public ResponseEntity<String> createComment(@Valid @RequestBody CommentCreateRequestDto request){
+    public ResponseEntity<BaseResponse<?>> createComment(@Valid @RequestBody CommentCreateRequestDto request){
         commentService.createComment(request.getUserId(),request);
-        return ResponseEntity.ok("Comment created");
+        return BaseResponse.ok(SuccessCode.ADDED_SUCCESS);
     }
 
     @GetMapping("/{taskId}")
-    public ResponseEntity<List<CommentResponseDto>> getComments(@PathVariable Long taskId){
+    public ResponseEntity<BaseResponse<List<CommentResponseDto>>> getComments(@PathVariable Long taskId){
         List<CommentResponseDto> comments = commentService.getComments(taskId);
-        return ResponseEntity.ok(comments);
+        return BaseResponse.ok(SuccessCode.GET_SUCCESS, comments);
     }
 }

--- a/src/main/java/io/powerrangers/backend/controller/FollowController.java
+++ b/src/main/java/io/powerrangers/backend/controller/FollowController.java
@@ -5,8 +5,6 @@ import io.powerrangers.backend.dto.FollowRequestDto;
 import io.powerrangers.backend.dto.FollowResponseDto;
 import io.powerrangers.backend.dto.SuccessCode;
 import io.powerrangers.backend.dto.UserFollowResponseDto;
-import io.powerrangers.backend.entity.Follow;
-import io.powerrangers.backend.entity.User;
 import io.powerrangers.backend.service.FollowService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -30,23 +28,23 @@ public class FollowController {
     // TODO : 이후 Authentication에서 ID 받아오기
     @PostMapping
     public ResponseEntity<BaseResponse<FollowResponseDto>> follow(@Valid @RequestBody FollowRequestDto followRequestDto){
-        return BaseResponse.ok(SuccessCode.ADDED_SUCCESS, followService.follow(followRequestDto));
+        return BaseResponse.success(SuccessCode.ADDED_SUCCESS, followService.follow(followRequestDto));
     }
 
     @DeleteMapping("/{followingId}")
     public ResponseEntity<BaseResponse<?>> unfollow(@PathVariable Long followingId){
         followService.unfollow(followingId);
-        return BaseResponse.ok(SuccessCode.DELETED_SUCCESS);
+        return BaseResponse.success(SuccessCode.DELETED_SUCCESS);
     }
 
     @GetMapping("/{userId}/followers")
     public ResponseEntity<BaseResponse<List<UserFollowResponseDto>>> getFollowers(@PathVariable Long userId){
-        return BaseResponse.ok(SuccessCode.GET_SUCCESS, followService.findFollowers(userId));
+        return BaseResponse.success(SuccessCode.GET_SUCCESS, followService.findFollowers(userId));
     }
 
     @GetMapping("/{userId}/followings")
     public ResponseEntity<BaseResponse<List<UserFollowResponseDto>>> getFollowings(@PathVariable Long userId){
-        return BaseResponse.ok(SuccessCode.GET_SUCCESS, followService.findFollowings(userId));
+        return BaseResponse.success(SuccessCode.GET_SUCCESS, followService.findFollowings(userId));
     }
 
 }

--- a/src/main/java/io/powerrangers/backend/controller/FollowController.java
+++ b/src/main/java/io/powerrangers/backend/controller/FollowController.java
@@ -1,7 +1,9 @@
 package io.powerrangers.backend.controller;
 
+import io.powerrangers.backend.dto.BaseResponse;
 import io.powerrangers.backend.dto.FollowRequestDto;
 import io.powerrangers.backend.dto.FollowResponseDto;
+import io.powerrangers.backend.dto.SuccessCode;
 import io.powerrangers.backend.dto.UserFollowResponseDto;
 import io.powerrangers.backend.entity.Follow;
 import io.powerrangers.backend.entity.User;
@@ -26,25 +28,24 @@ public class FollowController {
 
     // TODO : 이후 Authentication에서 ID 받아오기
     @PostMapping
-    public ResponseEntity<FollowResponseDto> follow(@RequestBody FollowRequestDto followRequestDto){
-        return ResponseEntity.ok(followService.follow(followRequestDto));
+    public ResponseEntity<BaseResponse<FollowResponseDto>> follow(@RequestBody FollowRequestDto followRequestDto){
+        return BaseResponse.ok(SuccessCode.ADDED_SUCCESS, followService.follow(followRequestDto));
     }
 
     @DeleteMapping("/{followingId}")
-    public ResponseEntity<Void> unfollow(@PathVariable Long followingId){
+    public ResponseEntity<BaseResponse<?>> unfollow(@PathVariable Long followingId){
         followService.unfollow(followingId);
-        return ResponseEntity.noContent().build();
+        return BaseResponse.ok(SuccessCode.DELETED_SUCCESS);
     }
 
     @GetMapping("/{userId}/followers")
-    public ResponseEntity<List<UserFollowResponseDto>> getFollowers(@PathVariable Long userId){
-
-        return ResponseEntity.ok(followService.findFollowers(userId));
+    public ResponseEntity<BaseResponse<List<UserFollowResponseDto>>> getFollowers(@PathVariable Long userId){
+        return BaseResponse.ok(SuccessCode.GET_SUCCESS, followService.findFollowers(userId));
     }
 
     @GetMapping("/{userId}/followings")
-    public ResponseEntity<List<UserFollowResponseDto>> getFollowings(@PathVariable Long userId){
-        return ResponseEntity.ok(followService.findFollowings(userId));
+    public ResponseEntity<BaseResponse<List<UserFollowResponseDto>>> getFollowings(@PathVariable Long userId){
+        return BaseResponse.ok(SuccessCode.GET_SUCCESS, followService.findFollowings(userId));
     }
 
 }

--- a/src/main/java/io/powerrangers/backend/controller/FollowController.java
+++ b/src/main/java/io/powerrangers/backend/controller/FollowController.java
@@ -8,6 +8,7 @@ import io.powerrangers.backend.dto.UserFollowResponseDto;
 import io.powerrangers.backend.entity.Follow;
 import io.powerrangers.backend.entity.User;
 import io.powerrangers.backend.service.FollowService;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +29,7 @@ public class FollowController {
 
     // TODO : 이후 Authentication에서 ID 받아오기
     @PostMapping
-    public ResponseEntity<BaseResponse<FollowResponseDto>> follow(@RequestBody FollowRequestDto followRequestDto){
+    public ResponseEntity<BaseResponse<FollowResponseDto>> follow(@Valid @RequestBody FollowRequestDto followRequestDto){
         return BaseResponse.ok(SuccessCode.ADDED_SUCCESS, followService.follow(followRequestDto));
     }
 

--- a/src/main/java/io/powerrangers/backend/controller/TaskController.java
+++ b/src/main/java/io/powerrangers/backend/controller/TaskController.java
@@ -8,7 +8,6 @@ import io.powerrangers.backend.dto.TaskUpdateRequestDto;
 import io.powerrangers.backend.service.TaskService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,30 +23,30 @@ public class TaskController {
     @PostMapping
     public ResponseEntity<BaseResponse<?>> createTask(@Valid @RequestBody TaskCreateRequestDto dto) {
         taskService.createTask(dto);
-        return BaseResponse.ok(SuccessCode.ADDED_SUCCESS);
+        return BaseResponse.success(SuccessCode.ADDED_SUCCESS);
     }
 
     @GetMapping("/{userId}")
     public ResponseEntity<BaseResponse<List<TaskResponseDto>>> getMyTasks(@PathVariable Long userId) {
-        return BaseResponse.ok(SuccessCode.GET_SUCCESS, taskService.getTasksByUser(userId));
+        return BaseResponse.success(SuccessCode.GET_SUCCESS, taskService.getTasksByUser(userId));
     }
 
     @PatchMapping("/{taskId}")
     public ResponseEntity<BaseResponse<?>> updateTask(@PathVariable Long taskId, @Valid @RequestBody TaskUpdateRequestDto dto) {
         taskService.updateTask(taskId, dto);
-        return BaseResponse.ok(SuccessCode.MODIFIED_SUCCESS);
+        return BaseResponse.success(SuccessCode.MODIFIED_SUCCESS);
     }
 
     @DeleteMapping("/{taskId}")
     public ResponseEntity<BaseResponse<?>> removeTask(@PathVariable Long taskId, @Valid @RequestBody TaskCreateRequestDto dto) {
         taskService.removeTask(taskId, dto);
-        return BaseResponse.ok(SuccessCode.DELETED_SUCCESS);
+        return BaseResponse.success(SuccessCode.DELETED_SUCCESS);
     }
 
     @PatchMapping("/{taskId}/status")
     public ResponseEntity<BaseResponse<?>> changeStatus(@PathVariable Long taskId, @Valid @RequestBody TaskCreateRequestDto dto) {
         taskService.changeStatus(taskId, dto.getUserId());
-        return BaseResponse.ok(SuccessCode.MODIFIED_SUCCESS);
+        return BaseResponse.success(SuccessCode.MODIFIED_SUCCESS);
     }
 }
 

--- a/src/main/java/io/powerrangers/backend/controller/TaskController.java
+++ b/src/main/java/io/powerrangers/backend/controller/TaskController.java
@@ -1,5 +1,7 @@
 package io.powerrangers.backend.controller;
 
+import io.powerrangers.backend.dto.BaseResponse;
+import io.powerrangers.backend.dto.SuccessCode;
 import io.powerrangers.backend.dto.TaskCreateRequestDto;
 import io.powerrangers.backend.dto.TaskResponseDto;
 import io.powerrangers.backend.dto.TaskUpdateRequestDto;
@@ -20,32 +22,32 @@ public class TaskController {
     private final TaskService taskService;
 
     @PostMapping
-    public ResponseEntity<Void> createTask(@RequestBody @Valid TaskCreateRequestDto dto) {
+    public ResponseEntity<BaseResponse<?>> createTask(@RequestBody @Valid TaskCreateRequestDto dto) {
         taskService.createTask(dto);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return BaseResponse.ok(SuccessCode.ADDED_SUCCESS);
     }
 
     @GetMapping("/{userId}")
-    public ResponseEntity<List<TaskResponseDto>> getMyTasks(@PathVariable Long userId) {
-        return ResponseEntity.ok(taskService.getTasksByUser(userId));
+    public ResponseEntity<BaseResponse<List<TaskResponseDto>>> getMyTasks(@PathVariable Long userId) {
+        return BaseResponse.ok(SuccessCode.GET_SUCCESS, taskService.getTasksByUser(userId));
     }
 
     @PatchMapping("/{taskId}")
-    public ResponseEntity<Void> updateTask(@PathVariable Long taskId, @RequestBody @Valid TaskUpdateRequestDto dto) {
+    public ResponseEntity<BaseResponse<?>> updateTask(@PathVariable Long taskId, @RequestBody @Valid TaskUpdateRequestDto dto) {
         taskService.updateTask(taskId, dto);
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok(SuccessCode.MODIFIED_SUCCESS);
     }
 
     @DeleteMapping("/{taskId}")
-    public ResponseEntity<Void> removeTask(@PathVariable Long taskId, @RequestBody @Valid TaskCreateRequestDto dto) {
+    public ResponseEntity<BaseResponse<?>> removeTask(@PathVariable Long taskId, @RequestBody @Valid TaskCreateRequestDto dto) {
         taskService.removeTask(taskId, dto);
-        return ResponseEntity.noContent().build();
+        return BaseResponse.ok(SuccessCode.DELETED_SUCCESS);
     }
 
     @PatchMapping("/{taskId}/status")
-    public ResponseEntity<Void> changeStatus(@PathVariable Long taskId, @RequestBody @Valid TaskCreateRequestDto dto) {
+    public ResponseEntity<BaseResponse<?>> changeStatus(@PathVariable Long taskId, @RequestBody @Valid TaskCreateRequestDto dto) {
         taskService.changeStatus(taskId, dto.getUserId());
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok(SuccessCode.MODIFIED_SUCCESS);
     }
 }
 

--- a/src/main/java/io/powerrangers/backend/controller/TaskController.java
+++ b/src/main/java/io/powerrangers/backend/controller/TaskController.java
@@ -22,7 +22,7 @@ public class TaskController {
     private final TaskService taskService;
 
     @PostMapping
-    public ResponseEntity<BaseResponse<?>> createTask(@RequestBody @Valid TaskCreateRequestDto dto) {
+    public ResponseEntity<BaseResponse<?>> createTask(@Valid @RequestBody TaskCreateRequestDto dto) {
         taskService.createTask(dto);
         return BaseResponse.ok(SuccessCode.ADDED_SUCCESS);
     }
@@ -33,19 +33,19 @@ public class TaskController {
     }
 
     @PatchMapping("/{taskId}")
-    public ResponseEntity<BaseResponse<?>> updateTask(@PathVariable Long taskId, @RequestBody @Valid TaskUpdateRequestDto dto) {
+    public ResponseEntity<BaseResponse<?>> updateTask(@PathVariable Long taskId, @Valid @RequestBody TaskUpdateRequestDto dto) {
         taskService.updateTask(taskId, dto);
         return BaseResponse.ok(SuccessCode.MODIFIED_SUCCESS);
     }
 
     @DeleteMapping("/{taskId}")
-    public ResponseEntity<BaseResponse<?>> removeTask(@PathVariable Long taskId, @RequestBody @Valid TaskCreateRequestDto dto) {
+    public ResponseEntity<BaseResponse<?>> removeTask(@PathVariable Long taskId, @Valid @RequestBody TaskCreateRequestDto dto) {
         taskService.removeTask(taskId, dto);
         return BaseResponse.ok(SuccessCode.DELETED_SUCCESS);
     }
 
     @PatchMapping("/{taskId}/status")
-    public ResponseEntity<BaseResponse<?>> changeStatus(@PathVariable Long taskId, @RequestBody @Valid TaskCreateRequestDto dto) {
+    public ResponseEntity<BaseResponse<?>> changeStatus(@PathVariable Long taskId, @Valid @RequestBody TaskCreateRequestDto dto) {
         taskService.changeStatus(taskId, dto.getUserId());
         return BaseResponse.ok(SuccessCode.MODIFIED_SUCCESS);
     }

--- a/src/main/java/io/powerrangers/backend/controller/UserController.java
+++ b/src/main/java/io/powerrangers/backend/controller/UserController.java
@@ -1,5 +1,7 @@
 package io.powerrangers.backend.controller;
 
+import io.powerrangers.backend.dto.BaseResponse;
+import io.powerrangers.backend.dto.SuccessCode;
 import io.powerrangers.backend.dto.UserGetProfileResponseDto;
 import io.powerrangers.backend.dto.UserUpdateProfileRequestDto;
 import io.powerrangers.backend.service.UserService;
@@ -16,12 +18,12 @@ public class UserController {
     private final UserService userService;
 
     @PatchMapping("/{userId}")
-    public ResponseEntity<UserUpdateProfileRequestDto> updateUserProfile(
+    public ResponseEntity<BaseResponse<?>> updateUserProfile(
             @PathVariable Long userId,
             @RequestBody UserUpdateProfileRequestDto request
     ){
         userService.updateUserProfile(userId, request);
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok(SuccessCode.MODIFIED_SUCCESS);
     }
 
     @PostMapping("/logout")
@@ -34,19 +36,18 @@ public class UserController {
     }
 
     @GetMapping("/{userId}")
-    public ResponseEntity<UserGetProfileResponseDto> getUserProfile(@PathVariable Long userId){
-
-        return ResponseEntity.ok(userService.getUserProfile(userId));
+    public ResponseEntity<BaseResponse<UserGetProfileResponseDto>> getUserProfile(@PathVariable Long userId){
+        return BaseResponse.ok(SuccessCode.GET_SUCCESS, userService.getUserProfile(userId));
     }
 
     @GetMapping()
-    public ResponseEntity<UserGetProfileResponseDto> searchUserProfile(@RequestParam String nickname){
-        return ResponseEntity.ok(userService.searchUserProfile(nickname));
+    public ResponseEntity<BaseResponse<UserGetProfileResponseDto>> searchUserProfile(@RequestParam String nickname){
+        return BaseResponse.ok(SuccessCode.GET_SUCCESS, userService.searchUserProfile(nickname));
     }
 
     @DeleteMapping("/{userId}")
-    public ResponseEntity<?> cancelAccount(@PathVariable Long userId){
+    public ResponseEntity<BaseResponse<?>> cancelAccount(@PathVariable Long userId){
         userService.cancelAccount(userId);
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok(SuccessCode.DELETED_SUCCESS);
     }
 }

--- a/src/main/java/io/powerrangers/backend/controller/UserController.java
+++ b/src/main/java/io/powerrangers/backend/controller/UserController.java
@@ -2,7 +2,6 @@ package io.powerrangers.backend.controller;
 
 import io.powerrangers.backend.dto.BaseResponse;
 import io.powerrangers.backend.dto.SuccessCode;
-import io.powerrangers.backend.dto.LogoutRequestDto;
 import io.powerrangers.backend.dto.UserGetProfileResponseDto;
 import io.powerrangers.backend.dto.UserUpdateProfileRequestDto;
 import io.powerrangers.backend.service.UserService;
@@ -23,23 +22,23 @@ public class UserController {
             @RequestBody UserUpdateProfileRequestDto request
     ){
         userService.updateUserProfile(userId, request);
-        return BaseResponse.ok(SuccessCode.MODIFIED_SUCCESS);
+        return BaseResponse.success(SuccessCode.MODIFIED_SUCCESS);
     }
 
     @GetMapping("/{userId}")
     public ResponseEntity<BaseResponse<UserGetProfileResponseDto>> getUserProfile(@PathVariable Long userId){
-        return BaseResponse.ok(SuccessCode.GET_SUCCESS, userService.getUserProfile(userId));
+        return BaseResponse.success(SuccessCode.GET_SUCCESS, userService.getUserProfile(userId));
     }
 
     @GetMapping()
     public ResponseEntity<BaseResponse<UserGetProfileResponseDto>> searchUserProfile(@RequestParam String nickname){
-        return BaseResponse.ok(SuccessCode.GET_SUCCESS, userService.searchUserProfile(nickname));
+        return BaseResponse.success(SuccessCode.GET_SUCCESS, userService.searchUserProfile(nickname));
     }
 
     @DeleteMapping("/{userId}")
     public ResponseEntity<BaseResponse<?>> cancelAccount(@PathVariable Long userId){
         userService.cancelAccount(userId);
-        return BaseResponse.ok(SuccessCode.DELETED_SUCCESS);
+        return BaseResponse.success(SuccessCode.DELETED_SUCCESS);
     }
 
     @PostMapping("/logout")

--- a/src/main/java/io/powerrangers/backend/dto/BaseResponse.java
+++ b/src/main/java/io/powerrangers/backend/dto/BaseResponse.java
@@ -13,15 +13,15 @@ public class BaseResponse<T> {
     private T data;
 
     //성공 메시지만 반환
-    public static ResponseEntity<BaseResponse<?>> ok(String message, HttpStatus status) {
-        return ResponseEntity.status(status)
-                .body(new BaseResponse<>(status.value(), message, null));
+    public static ResponseEntity<BaseResponse<?>> ok(SuccessCode successCode) {
+        return ResponseEntity.status(successCode.getStatus())
+                .body(new BaseResponse<>(successCode.getStatus().value(), successCode.getMessage(), null));
     }
 
     //성공 메시지와 데이터 반환
-    public static <T> ResponseEntity<BaseResponse<T>> ok(String message, T data, HttpStatus status) {
-        return ResponseEntity.status(status)
-                .body(new BaseResponse<>(status.value(), message, data));
+    public static <T> ResponseEntity<BaseResponse<T>> ok(SuccessCode successCode, T data) {
+        return ResponseEntity.status(successCode.getStatus())
+                .body(new BaseResponse<>(successCode.getStatus().value(), successCode.getMessage(), data));
     }
 
     //에러 메시지만 반환

--- a/src/main/java/io/powerrangers/backend/dto/BaseResponse.java
+++ b/src/main/java/io/powerrangers/backend/dto/BaseResponse.java
@@ -1,4 +1,4 @@
-package io.powerrangers.backend.global;
+package io.powerrangers.backend.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/io/powerrangers/backend/dto/BaseResponse.java
+++ b/src/main/java/io/powerrangers/backend/dto/BaseResponse.java
@@ -13,13 +13,13 @@ public class BaseResponse<T> {
     private T data;
 
     //성공 메시지만 반환
-    public static ResponseEntity<BaseResponse<?>> ok(SuccessCode successCode) {
+    public static ResponseEntity<BaseResponse<?>> success(SuccessCode successCode) {
         return ResponseEntity.status(successCode.getStatus())
                 .body(new BaseResponse<>(successCode.getStatus().value(), successCode.getMessage(), null));
     }
 
     //성공 메시지와 데이터 반환
-    public static <T> ResponseEntity<BaseResponse<T>> ok(SuccessCode successCode, T data) {
+    public static <T> ResponseEntity<BaseResponse<T>> success(SuccessCode successCode, T data) {
         return ResponseEntity.status(successCode.getStatus())
                 .body(new BaseResponse<>(successCode.getStatus().value(), successCode.getMessage(), data));
     }

--- a/src/main/java/io/powerrangers/backend/dto/FollowRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/FollowRequestDto.java
@@ -1,5 +1,6 @@
 package io.powerrangers.backend.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,10 @@ import lombok.NoArgsConstructor;
 public class FollowRequestDto {
 
     // TODO : 이후 Authentication에서 로그인한 사용자의 ID를 꺼내서 사용해야 하기 때문에 나중에 Dto에서 빼주기
+    @NotNull(message = "팔로워 ID는 필수입니다.")
     private final Long followerId;
+
+    @NotNull(message = "팔로잉 ID는 필수입니다.")
     private final Long followingId;
 
 }

--- a/src/main/java/io/powerrangers/backend/dto/SuccessCode.java
+++ b/src/main/java/io/powerrangers/backend/dto/SuccessCode.java
@@ -1,0 +1,25 @@
+package io.powerrangers.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessCode {
+
+    // 200 OK
+    MODIFIED_SUCCESS(200, "수정이 성공적으로 수행되었습니다."),
+    GET_SUCCESS(200, "데이터를 성공적으로 가져왔습니다."),
+    DELETED_SUCCESS(200, "삭제가 성공적으로 수행되었습니다."),
+
+    // 201 Created
+    ADDED_SUCCESS(201, "데이터가 성공적으로 추가되었습니다.");
+
+    private final int status;
+    private final String message;
+
+    public HttpStatus getStatus() {
+        return HttpStatus.valueOf(status);
+    }
+}

--- a/src/main/java/io/powerrangers/backend/dto/SuccessCode.java
+++ b/src/main/java/io/powerrangers/backend/dto/SuccessCode.java
@@ -9,17 +9,16 @@ import org.springframework.http.HttpStatus;
 public enum SuccessCode {
 
     // 200 OK
-    MODIFIED_SUCCESS(200, "수정이 성공적으로 수행되었습니다."),
-    GET_SUCCESS(200, "데이터를 성공적으로 가져왔습니다."),
-    DELETED_SUCCESS(200, "삭제가 성공적으로 수행되었습니다."),
+    MODIFIED_SUCCESS(HttpStatus.OK, "수정이 성공적으로 수행되었습니다."),
+    GET_SUCCESS(HttpStatus.OK, "데이터를 성공적으로 가져왔습니다."),
 
     // 201 Created
-    ADDED_SUCCESS(201, "데이터가 성공적으로 추가되었습니다.");
+    ADDED_SUCCESS(HttpStatus.CREATED, "데이터가 성공적으로 추가되었습니다."),
 
-    private final int status;
+    // 204 No Content
+    DELETED_SUCCESS(HttpStatus.NO_CONTENT, "삭제가 성공적으로 수행되었습니다.");
+
+    private final HttpStatus status;
     private final String message;
 
-    public HttpStatus getStatus() {
-        return HttpStatus.valueOf(status);
-    }
 }

--- a/src/main/java/io/powerrangers/backend/dto/TaskCreateRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/TaskCreateRequestDto.java
@@ -1,6 +1,7 @@
 package io.powerrangers.backend.dto;
 
 import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,10 +16,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(force = true)
 public class TaskCreateRequestDto {
 
-    @NotNull(message="카테고리를 지정하지 않았습니다")
+    @NotBlank(message="카테고리를 지정하지 않았습니다.")
     private final String category;
 
-    @NotNull(message="내용을 지정하지 않았습니다")
+    @NotBlank(message="내용을 지정하지 않았습니다.")
     private final String content;
 
     @NotNull(message = "기한을 지정하지 않았습니다")

--- a/src/main/java/io/powerrangers/backend/dto/TaskCreateRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/TaskCreateRequestDto.java
@@ -22,19 +22,19 @@ public class TaskCreateRequestDto {
     @NotBlank(message="내용을 지정하지 않았습니다.")
     private final String content;
 
-    @NotNull(message = "기한을 지정하지 않았습니다")
-    @Future(message = "기한은 미래로 지정해야 합니다")
+    @NotNull(message = "기한을 지정하지 않았습니다.")
+    @Future(message = "기한은 미래로 지정해야 합니다.")
     private final LocalDateTime dueDate;
 
-    @NotNull(message = "상태를 지정하지 않았습니다")
+    @NotNull(message = "상태를 지정하지 않았습니다.")
     private final TaskStatus status;
 
     private final String taskImage;
 
-    @NotNull(message = "공개 범위를 지정하지 않았습니다")
+    @NotNull(message = "공개 범위를 지정하지 않았습니다.")
     private final TaskScope scope;
 
-    @NotNull(message = "사용자 ID를 지정하지 않았습니다")
+    @NotNull(message = "사용자 ID를 지정하지 않았습니다.")
     private final Long userId;  // 시큐리티 적용 전 테스트용 사용자 ID
 
 }

--- a/src/main/java/io/powerrangers/backend/dto/TaskUpdateRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/TaskUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package io.powerrangers.backend.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,10 +14,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(force = true)
 public class TaskUpdateRequestDto {
 
-    @NotNull(message="카테고리를 지정하지 않았습니다")
+    @NotBlank(message="카테고리를 지정하지 않았습니다")
     private final String category;
 
-    @NotNull(message="내용을 지정하지 않았습니다")
+    @NotBlank(message="내용을 지정하지 않았습니다")
     private final String content;
 
     @NotNull(message = "공개 범위를 지정하지 않았습니다")

--- a/src/main/java/io/powerrangers/backend/dto/UserUpdateProfileRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/UserUpdateProfileRequestDto.java
@@ -1,5 +1,6 @@
 package io.powerrangers.backend.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,8 +12,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(force = true)
 public class UserUpdateProfileRequestDto{
 
+    @NotBlank(message="닉네임을 지정해주세요.")
     private final String nickname;
+
     private final String intro;
+
     private final String profileImage;
 
 }

--- a/src/main/java/io/powerrangers/backend/exception/CustomException.java
+++ b/src/main/java/io/powerrangers/backend/exception/CustomException.java
@@ -1,0 +1,10 @@
+package io.powerrangers.backend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
+++ b/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
@@ -9,32 +9,28 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // 400 Bad Request
-    INVALID_REQUEST(400, "요청 데이터가 올바르지 않습니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청 데이터가 올바르지 않습니다."),
 
     // 401 Unauthorized
-    UNAUTHORIZED(401, "유효하지 않은 인증입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증입니다."),
 
     // 403 Forbidden
-    NOT_THE_OWNER(403,"할 일에 대한 권한이 없습니다."),
+    NOT_THE_OWNER(HttpStatus.UNAUTHORIZED,"할 일에 대한 권한이 없습니다."),
 
     // 404 Not Found
-    USER_NOT_FOUND(404, "존재하지 않는 사용자입니다."),
-    TASK_NOT_FOUND(404, "존재하지 않는 할 일입니다."),
-    COMMENT_NOT_FOUND(404, "존재하지 않는 댓글입니다."),
-    FOLLOW_NOT_FOUND(404, "팔로우 관계를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 할 일입니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
+    FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "팔로우 관계를 찾을 수 없습니다."),
 
     // 409 Conflict
-    DUPLICATED_NICKNAME(409, "이미 존재하는 닉네임입니다."),
-    ALREADY_FOLLOWED(409, "이미 팔로우한 사용자입니다."),
+    DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
+    ALREADY_FOLLOWED(HttpStatus.CONFLICT, "이미 팔로우한 사용자입니다."),
 
     // 500 INTERNAL_SERVER ERROR
-    INTERNAL_SERVER_ERROR(500,"서버 에러입니다. 서버 팀에게 문의해주세요.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"서버 에러입니다. 서버 팀에게 문의해주세요.");
 
-    private final int status;
+    private final HttpStatus status;
     private final String message;
-
-    public HttpStatus getStatus() {
-        return HttpStatus.valueOf(status);
-    }
 
 }

--- a/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
+++ b/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
@@ -1,0 +1,32 @@
+package io.powerrangers.backend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // 400 Bad Request
+    INVALID_REQUEST(400, "잘못된 입력값입니다."),
+
+    // 403 Forbidden
+    NOT_THE_OWNER(403,"할 일에 대한 권한이 없습니다."),
+
+    // 404 Not Found
+    USER_NOT_FOUND(404, "존재하지 않는 사용자입니다."),
+    TASK_NOT_FOUND(404, "존재하지 않는 할 일입니다."),
+    COMMENT_NOT_FOUND(404, "존재하지 않는 댓글입니다."),
+    FOLLOW_NOT_FOUND(404, "팔로우 관계를 찾을 수 없습니다."),
+
+    // 409 Conflict
+    DUPLICATED_NICKNAME(409, "이미 존재하는 닉네임입니다."),
+    ALREADY_FOLLOWED(409, "이미 팔로우한 사용자입니다."),
+
+    // 500 INTERNAL_SERVER ERROR
+    INTERNAL_SERVER_ERROR(500,"서버 에러입니다. 서버 팀에게 문의해주세요.");
+
+    private final int status;
+    private final String message;
+
+}

--- a/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
+++ b/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
@@ -2,6 +2,7 @@ package io.powerrangers.backend.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
@@ -28,5 +29,9 @@ public enum ErrorCode {
 
     private final int status;
     private final String message;
+
+    public HttpStatus getStatus() {
+        return HttpStatus.valueOf(status);
+    }
 
 }

--- a/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
+++ b/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // 400 Bad Request
-    INVALID_REQUEST(400, "잘못된 입력값입니다."),
+    INVALID_REQUEST(400, "요청 데이터가 올바르지 않습니다."),
+
+    // 401 Unauthorized
+    UNAUTHORIZED(401, "유효하지 않은 인증입니다."),
 
     // 403 Forbidden
     NOT_THE_OWNER(403,"할 일에 대한 권한이 없습니다."),

--- a/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -33,7 +34,7 @@ public class GlobalExceptionHandler {
         return BaseResponse.error(errorMessage, errorCode.getStatus());
     }
 
-    @ExceptionHandler({HttpMessageNotReadableException.class})
+    @ExceptionHandler({HttpMessageNotReadableException.class, MissingServletRequestParameterException.class})
     protected ResponseEntity<BaseResponse<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         return BaseResponse.error(ErrorCode.INVALID_REQUEST.getMessage(), ErrorCode.INVALID_REQUEST.getStatus());
     }

--- a/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
@@ -1,11 +1,36 @@
 package io.powerrangers.backend.exception;
 
+import io.powerrangers.backend.global.BaseResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler({CustomException.class})
+    protected ResponseEntity<BaseResponse<?>> handleCustomException(CustomException e) {
+        return BaseResponse.error(e.getErrorCode().getMessage(), HttpStatus.valueOf(e.getErrorCode().getStatus()));
+    }
 
+    @ExceptionHandler({MethodArgumentNotValidException.class})
+    protected ResponseEntity<BaseResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+        return BaseResponse.error(errorCode.getMessage(), HttpStatus.valueOf(errorCode.getStatus()));
+    }
 
+    @ExceptionHandler({HttpMessageNotReadableException.class})
+    protected ResponseEntity<BaseResponse<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+        return BaseResponse.error(errorCode.getMessage(), HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+    @ExceptionHandler({Exception.class})
+    protected ResponseEntity<BaseResponse<?>> handleException(Exception e) {
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        return BaseResponse.error(errorCode.getMessage(), HttpStatus.valueOf(errorCode.getStatus()));
+    }
 }

--- a/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,11 @@
+package io.powerrangers.backend.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+
+
+}

--- a/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package io.powerrangers.backend.exception;
 
-import io.powerrangers.backend.global.BaseResponse;
+import io.powerrangers.backend.dto.BaseResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -13,24 +13,24 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({CustomException.class})
     protected ResponseEntity<BaseResponse<?>> handleCustomException(CustomException e) {
-        return BaseResponse.error(e.getErrorCode().getMessage(), HttpStatus.valueOf(e.getErrorCode().getStatus()));
+        return BaseResponse.error(e.getErrorCode().getMessage(), e.getErrorCode().getStatus());
     }
 
     @ExceptionHandler({MethodArgumentNotValidException.class})
     protected ResponseEntity<BaseResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
-        return BaseResponse.error(errorCode.getMessage(), HttpStatus.valueOf(errorCode.getStatus()));
+        return BaseResponse.error(errorCode.getMessage(), errorCode.getStatus());
     }
 
     @ExceptionHandler({HttpMessageNotReadableException.class})
     protected ResponseEntity<BaseResponse<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
-        return BaseResponse.error(errorCode.getMessage(), HttpStatus.valueOf(errorCode.getStatus()));
+        return BaseResponse.error(errorCode.getMessage(), errorCode.getStatus());
     }
 
     @ExceptionHandler({Exception.class})
     protected ResponseEntity<BaseResponse<?>> handleException(Exception e) {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-        return BaseResponse.error(errorCode.getMessage(), HttpStatus.valueOf(errorCode.getStatus()));
+        return BaseResponse.error(errorCode.getMessage(), errorCode.getStatus());
     }
 }

--- a/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
@@ -1,9 +1,12 @@
 package io.powerrangers.backend.exception;
 
 import io.powerrangers.backend.dto.BaseResponse;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -18,14 +21,21 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({MethodArgumentNotValidException.class})
     protected ResponseEntity<BaseResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+
+        String errorMessage = fieldErrors.stream()
+                .map(error -> error.getField() + " : " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+
         ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
-        return BaseResponse.error(errorCode.getMessage(), errorCode.getStatus());
+
+        return BaseResponse.error(errorMessage, errorCode.getStatus());
     }
 
     @ExceptionHandler({HttpMessageNotReadableException.class})
     protected ResponseEntity<BaseResponse<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
-        ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
-        return BaseResponse.error(errorCode.getMessage(), errorCode.getStatus());
+        return BaseResponse.error(ErrorCode.INVALID_REQUEST.getMessage(), ErrorCode.INVALID_REQUEST.getStatus());
     }
 
     @ExceptionHandler({Exception.class})

--- a/src/main/java/io/powerrangers/backend/global/BaseResponse.java
+++ b/src/main/java/io/powerrangers/backend/global/BaseResponse.java
@@ -1,0 +1,37 @@
+package io.powerrangers.backend.global;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@AllArgsConstructor
+public class BaseResponse<T> {
+    private int status;
+    private String message;
+    private T data;
+
+    //성공 메시지만 반환
+    public static ResponseEntity<BaseResponse<?>> ok(String message, HttpStatus status) {
+        return ResponseEntity.status(status)
+                .body(new BaseResponse<>(status.value(), message, null));
+    }
+
+    //성공 메시지와 데이터 반환
+    public static <T> ResponseEntity<BaseResponse<T>> ok(String message, T data, HttpStatus status) {
+        return ResponseEntity.status(status)
+                .body(new BaseResponse<>(status.value(), message, data));
+    }
+
+    //에러 메시지만 반환
+    public static ResponseEntity<BaseResponse<?>> error(String message, HttpStatus status) {
+        return ResponseEntity.status(status)
+                .body(new BaseResponse<>(status.value(), message, null));
+    }
+    //에러 메시지와 데이터를 반환
+    public static <T> ResponseEntity<BaseResponse<T>> error(String message, T data, HttpStatus status) {
+        return ResponseEntity.status(status)
+                .body(new BaseResponse<>(status.value(), message, data));
+    }
+}

--- a/src/main/java/io/powerrangers/backend/service/CommentService.java
+++ b/src/main/java/io/powerrangers/backend/service/CommentService.java
@@ -54,6 +54,9 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public List<CommentResponseDto> getComments(Long taskId){
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
+
         List<Comment> allComments = commentRepository.findByTaskId(taskId);
 
         // 부모 댓글만 필터링

--- a/src/main/java/io/powerrangers/backend/service/CommentService.java
+++ b/src/main/java/io/powerrangers/backend/service/CommentService.java
@@ -8,6 +8,8 @@ import io.powerrangers.backend.entity.Comment;
 import io.powerrangers.backend.entity.Task;
 import io.powerrangers.backend.entity.User;
 import io.powerrangers.backend.dao.CommentRepository;
+import io.powerrangers.backend.exception.CustomException;
+import io.powerrangers.backend.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,15 +37,15 @@ public class CommentService {
     @Transactional
     public void createComment(Long userId, CommentCreateRequestDto request) {
         Task task = taskRepository.findById(request.getTaskId())
-                .orElseThrow(() -> new IllegalArgumentException("해당 Task 없음"));
+                .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자 없음"));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         Comment parent = null;
         if (request.getParentId() != null) {
             parent = commentRepository.findById(request.getParentId())
-                    .orElseThrow(() -> new IllegalArgumentException("해당 부모 댓글 없음"));
+                    .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
         }
 
         Comment comment = new Comment(task, user, parent, request.getContent());

--- a/src/main/java/io/powerrangers/backend/service/ContextUtil.java
+++ b/src/main/java/io/powerrangers/backend/service/ContextUtil.java
@@ -1,6 +1,8 @@
 package io.powerrangers.backend.service;
 
 import io.powerrangers.backend.dto.UserDetails;
+import io.powerrangers.backend.exception.CustomException;
+import io.powerrangers.backend.exception.ErrorCode;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -12,7 +14,7 @@ public class ContextUtil {
     public static Long getCurrentUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
-            throw new RuntimeException("인증된 사용자가 없습니다.");
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
         UserDetails principal = (UserDetails) authentication.getPrincipal();

--- a/src/main/java/io/powerrangers/backend/service/CustomOauth2UserService.java
+++ b/src/main/java/io/powerrangers/backend/service/CustomOauth2UserService.java
@@ -3,6 +3,8 @@ package io.powerrangers.backend.service;
 import io.powerrangers.backend.dao.UserRepository;
 import io.powerrangers.backend.dto.UserDetails;
 import io.powerrangers.backend.entity.User;
+import io.powerrangers.backend.exception.CustomException;
+import io.powerrangers.backend.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -20,7 +22,7 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
 
     public UserDetails getUserDetails(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(
-                () -> new RuntimeException("존재하지 않는 유저입니다."));
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
         return UserDetails.from(user);
     }
 

--- a/src/main/java/io/powerrangers/backend/service/TaskService.java
+++ b/src/main/java/io/powerrangers/backend/service/TaskService.java
@@ -5,6 +5,8 @@ import io.powerrangers.backend.dto.*;
 import io.powerrangers.backend.entity.Task;
 import io.powerrangers.backend.entity.User;
 import io.powerrangers.backend.dao.TaskRepository;
+import io.powerrangers.backend.exception.CustomException;
+import io.powerrangers.backend.exception.ErrorCode;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +24,7 @@ public class TaskService {
     @Transactional
     public void createTask(TaskCreateRequestDto dto) {
         User user = userRepository.findById(dto.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         Task task = Task.builder()
                 .category(dto.getCategory())
@@ -59,9 +61,9 @@ public class TaskService {
 
     private Task getTaskIfOwner(Long id, Long userId) {
         Task task = taskRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("할 일을 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
         if (!task.getUser().getId().equals(userId)) {
-            throw new IllegalArgumentException("할 일의 소유자가 아닙니다.");
+            throw new CustomException(ErrorCode.NOT_THE_OWNER);
         }
         return task;
     }

--- a/src/main/java/io/powerrangers/backend/service/UserService.java
+++ b/src/main/java/io/powerrangers/backend/service/UserService.java
@@ -4,6 +4,8 @@ import io.powerrangers.backend.dao.UserRepository;
 import io.powerrangers.backend.dto.UserGetProfileResponseDto;
 import io.powerrangers.backend.dto.UserUpdateProfileRequestDto;
 import io.powerrangers.backend.entity.User;
+import io.powerrangers.backend.exception.CustomException;
+import io.powerrangers.backend.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,7 +27,7 @@ public class UserService {
     public UserGetProfileResponseDto getUserProfile(Long userId){
         User findUser =
                 userRepository.findUserById(userId)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         UserGetProfileResponseDto userGetProfileResponseDto = UserGetProfileResponseDto.builder()
                 .nickname(findUser.getNickname())
@@ -40,7 +42,7 @@ public class UserService {
     public UserGetProfileResponseDto searchUserProfile(String nickname){
         User findUser =
                 userRepository.findUserByNickname(nickname)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         UserGetProfileResponseDto userGetProfileResponseDto = UserGetProfileResponseDto.builder()
                 .nickname(findUser.getNickname())
@@ -62,10 +64,10 @@ public class UserService {
     @Transactional
     public void updateUserProfile(Long userId, UserUpdateProfileRequestDto request){
         User user = userRepository.findUserById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         if(!user.getNickname().equals(request.getNickname()) && checkNicknameDuplication(request.getNickname())){
-            throw new IllegalArgumentException("닉네임이 중복됩니다.");
+            throw new CustomException(ErrorCode.DUPLICATED_NICKNAME);
         }
 
         user.setNickname(request.getNickname());
@@ -76,7 +78,7 @@ public class UserService {
     @Transactional
     public void cancelAccount(Long userId){
         User user = userRepository.findUserById(userId)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         userRepository.deleteById(userId);
     }
 


### PR DESCRIPTION
## 🛰️ Issue Number
- #29 

## 🪐 작업 내용
### 1. BaseResponse
```public class BaseResponse<T> {
    private int status;
    private String message;
    private T data;

    //성공 메시지만 반환
    public static ResponseEntity<BaseResponse<?>> success(SuccessCode successCode) {
        return ResponseEntity.status(successCode.getStatus())
                .body(new BaseResponse<>(successCode.getStatus().value(), successCode.getMessage(), null));
    }

    //성공 메시지와 데이터 반환
    public static <T> ResponseEntity<BaseResponse<T>> success(SuccessCode successCode, T data) {
        return ResponseEntity.status(successCode.getStatus())
                .body(new BaseResponse<>(successCode.getStatus().value(), successCode.getMessage(), data));
    }

    //에러 메시지만 반환
    public static ResponseEntity<BaseResponse<?>> error(String message, HttpStatus status) {
        return ResponseEntity.status(status)
                .body(new BaseResponse<>(status.value(), message, null));
    }
    //에러 메시지와 데이터를 반환
    public static <T> ResponseEntity<BaseResponse<T>> error(String message, T data, HttpStatus status) {
        return ResponseEntity.status(status)
                .body(new BaseResponse<>(status.value(), message, data));
    }
}
```
- 성공했을 때는 `success()`, 예외가 발생했을 때는 `error()` 메서드를 사용합니다.
- data를 함께 보내고 싶냐 아니냐에 따라 인자를 넣어 사용하시면 됩니다.

### 2. SuccessCode & ErrorCode
#### 1) SuccessCode
```
// 200 OK
MODIFIED_SUCCESS(HttpStatus.OK, "수정이 성공적으로 수행되었습니다."),
GET_SUCCESS(200, "데이터를 성공적으로 가져왔습니다."),

// 201 Created
ADDED_SUCCESS(HttpStatus.CREATED, "데이터가 성공적으로 추가되었습니다."),

// 204 No Content
DELETED_SUCCESS(HttpStatus.NO_CONTENT, "삭제가 성공적으로 수행되었습니다.");
```
- 이정도로만 구현해두었고, 컨트롤러 측에서 아래와 같이 사용하면 됩니다.
- StatusCode와 응답 메세지를 가지고 있습니다.
- 204 로 보낼 경우, 응답 바디가 담기지 않기 때문에, 삭제 메세지는 사실상 사용되지 않습니다. 다만, 가독성(?)을 위해 살려두었습니다.

`return BaseResponse.ok(SuccessCode.ADDED_SUCCESS);`

#### 2) ErrorCode
```
@Getter
@AllArgsConstructor
public enum ErrorCode {

    // 400 Bad Request
    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청 데이터가 올바르지 않습니다."),

    // 401 Unauthorized
    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증입니다."),

    // 403 Forbidden
    NOT_THE_OWNER(HttpStatus.FORBIDDEN,"할 일에 대한 권한이 없습니다."),

    // 404 Not Found
    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
    TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 할 일입니다."),
    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
    FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "팔로우 관계를 찾을 수 없습니다."),

    // 409 Conflict
    DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
    ALREADY_FOLLOWED(HttpStatus.CONFLICT, "이미 팔로우한 사용자입니다."),

    // 500 INTERNAL_SERVER ERROR
    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"서버 에러입니다. 서버 팀에게 문의해주세요.");
```
- 위와 같이 구현해두었습니다. 
- HttpStatus와 메세지를 넣어두었습니다. 
- 예외가 발생했을 때 다음과 같이 사용하면 됩니다.

```
Follow follow = followRepository.findByFollowerAndFollowing(follower, following)
                .orElseThrow(() -> new CustomException(ErrorCode.FOLLOW_NOT_FOUND));
```

### 3. GlobalExceptionHandler
발생하는 예외 종류에 따라 분류해두었습니다. 
- `CustomException`은 보통 서비스단에서 발생하는 예외들입니다.
- `MethodArgumentNotValidException` : `@Valid` 유효성 검사에서 발생하는 예외
- `HttpMessageNotReadableException`, `MissingServletRequestParameterException` : Json 파싱이 불가할 때, 쿼리 파라미터를 넣지 않았을 때

## 📚 Reference


## ✅ Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [X] 포스트맨으로 테스트했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?