### PR TITLE
Feat : 인증 관련 예외 처리 및 이미지 예외 처리 개선

### DIFF
--- a/src/main/java/io/powerrangers/backend/controller/TaskController.java
+++ b/src/main/java/io/powerrangers/backend/controller/TaskController.java
@@ -23,7 +23,6 @@ import java.util.List;
 public class TaskController {
 
     private final TaskService taskService;
-    private final S3Service s3Service;
 
     @PostMapping
     public ResponseEntity<BaseResponse<?>> createTask(@Valid @RequestBody TaskCreateRequestDto dto) {
@@ -55,15 +54,9 @@ public class TaskController {
     }
 
     @PatchMapping("/{taskId}/image")
-    public ResponseEntity<?> uploadImage(@RequestPart("image") MultipartFile file, @PathVariable Long taskId, @RequestPart TaskCreateRequestDto dto) {
-        taskService.validFile(file);
-        try {
-            String imageUrl = s3Service.upload(file);
-            taskService.updateTaskImage(taskId, imageUrl);
-            return ResponseEntity.ok().body(imageUrl);
-        } catch (IOException e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("업로드 실패: " + e.getMessage());
-        }
+    public ResponseEntity<?> uploadImage(@RequestPart("image") MultipartFile file, @PathVariable Long taskId, @RequestPart TaskCreateRequestDto dto) throws IOException {
+        String imageUrl = taskService.uploadTaskImage(file, taskId);
+        return ResponseEntity.ok().body(imageUrl);
     }
 }
 

--- a/src/main/java/io/powerrangers/backend/exception/AuthTokenException.java
+++ b/src/main/java/io/powerrangers/backend/exception/AuthTokenException.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/io/powerrangers/backend/exception/AuthTokenException.java
+++ b/src/main/java/io/powerrangers/backend/exception/AuthTokenException.java
@@ -1,0 +1,17 @@
+package io.powerrangers.backend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+@AllArgsConstructor
+public class AuthTokenException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private String provider = null;
+
+    public AuthTokenException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
+++ b/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     ALREADY_FOLLOWED(HttpStatus.CONFLICT, "이미 팔로우한 사용자입니다."),
 
+    // 415 Unsupported Media Type
+    UNSUPPORTED_RESOURCE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 파일 형식입니다. 이미지 파일만 업로드해주세요."),
+
     // 500 INTERNAL_SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"서버 에러입니다. 서버 팀에게 문의해주세요.");
 

--- a/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
+++ b/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     // 409 Conflict
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     ALREADY_FOLLOWED(HttpStatus.CONFLICT, "이미 팔로우한 사용자입니다."),
+    ALREADY_SIGNED_IN(HttpStatus.CONFLICT, "이미 다른 제공자로 로그인한 적이 있습니다."),
 
     // 415 Unsupported Media Type
     UNSUPPORTED_RESOURCE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 파일 형식입니다. 이미지 파일만 업로드해주세요."),

--- a/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
+++ b/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
@@ -10,9 +10,11 @@ public enum ErrorCode {
 
     // 400 Bad Request
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청 데이터가 올바르지 않습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
 
     // 401 Unauthorized
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
+    UNSUPPORTED_PROVIDER(HttpStatus.UNAUTHORIZED, "지원하지 않는 제공자입니다."),
 
     // 403 Forbidden
     NOT_THE_OWNER(HttpStatus.FORBIDDEN,"해당 작업에 대한 권한이 없습니다."),

--- a/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
@@ -19,11 +19,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({CustomException.class, AuthTokenException.class})
     protected ResponseEntity<BaseResponse<?>> handleCustomException(CustomException e) {
-        String message = e.getMessage();
-        if(!Objects.equals(e.getProvider(), null)){
-            message += " : " + e.getProvider();
-        }
-        return BaseResponse.error(message, e.getErrorCode().getStatus());
+        return BaseResponse.error(e.getErrorCode().getMessage(), e.getErrorCode().getStatus());
     }
 
     @ExceptionHandler({MethodArgumentNotValidException.class})

--- a/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package io.powerrangers.backend.exception;
 import io.powerrangers.backend.dto.BaseResponse;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,9 +17,13 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler({CustomException.class})
+    @ExceptionHandler({CustomException.class, AuthTokenException.class})
     protected ResponseEntity<BaseResponse<?>> handleCustomException(CustomException e) {
-        return BaseResponse.error(e.getErrorCode().getMessage(), e.getErrorCode().getStatus());
+        String message = e.getMessage();
+        if(!Objects.equals(e.getProvider(), null)){
+            message += " : " + e.getProvider();
+        }
+        return BaseResponse.error(message, e.getErrorCode().getStatus());
     }
 
     @ExceptionHandler({MethodArgumentNotValidException.class})
@@ -38,12 +43,6 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({HttpMessageNotReadableException.class, MissingServletRequestParameterException.class})
     protected ResponseEntity<BaseResponse<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         return BaseResponse.error(ErrorCode.INVALID_REQUEST.getMessage(), ErrorCode.INVALID_REQUEST.getStatus());
-    }
-
-    @ExceptionHandler({IOException.class})
-    protected ResponseEntity<BaseResponse<?>> handleIOException(Exception e) {
-        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-        return BaseResponse.error(errorCode.getMessage(), errorCode.getStatus());
     }
 
     @ExceptionHandler({IOException.class, Exception.class})

--- a/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package io.powerrangers.backend.exception;
 
 import io.powerrangers.backend.dto.BaseResponse;
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
@@ -39,7 +40,13 @@ public class GlobalExceptionHandler {
         return BaseResponse.error(ErrorCode.INVALID_REQUEST.getMessage(), ErrorCode.INVALID_REQUEST.getStatus());
     }
 
-    @ExceptionHandler({Exception.class})
+    @ExceptionHandler({IOException.class})
+    protected ResponseEntity<BaseResponse<?>> handleIOException(Exception e) {
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        return BaseResponse.error(errorCode.getMessage(), errorCode.getStatus());
+    }
+
+    @ExceptionHandler({IOException.class, Exception.class})
     protected ResponseEntity<BaseResponse<?>> handleException(Exception e) {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         return BaseResponse.error(errorCode.getMessage(), errorCode.getStatus());

--- a/src/main/java/io/powerrangers/backend/service/ContextUtil.java
+++ b/src/main/java/io/powerrangers/backend/service/ContextUtil.java
@@ -2,6 +2,7 @@ package io.powerrangers.backend.service;
 
 import io.powerrangers.backend.dto.Role;
 import io.powerrangers.backend.dto.UserDetails;
+import io.powerrangers.backend.exception.AuthTokenException;
 import io.powerrangers.backend.exception.CustomException;
 import io.powerrangers.backend.exception.ErrorCode;
 import org.springframework.security.core.Authentication;
@@ -15,7 +16,7 @@ public class ContextUtil {
     public static Long getCurrentUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
+            throw new AuthTokenException(ErrorCode.UNAUTHORIZED);
         }
 
         UserDetails principal = (UserDetails) authentication.getPrincipal();

--- a/src/main/java/io/powerrangers/backend/service/CustomOauth2UserService.java
+++ b/src/main/java/io/powerrangers/backend/service/CustomOauth2UserService.java
@@ -3,6 +3,7 @@ package io.powerrangers.backend.service;
 import io.powerrangers.backend.dao.UserRepository;
 import io.powerrangers.backend.dto.UserDetails;
 import io.powerrangers.backend.entity.User;
+import io.powerrangers.backend.exception.AuthTokenException;
 import io.powerrangers.backend.exception.CustomException;
 import io.powerrangers.backend.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,7 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
 
     public UserDetails getUserDetails(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(
-                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                () -> new AuthTokenException(ErrorCode.USER_NOT_FOUND));
         return UserDetails.from(user);
     }
 
@@ -50,7 +51,7 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
             log.info("userDetails = {}", userDetails);
             return userDetails.setId(findUser.getId()).setRole(findUser.getRole());
         } else {
-            throw new OAuth2AuthenticationException("User already registered with another provider.");
+            throw new AuthTokenException(ErrorCode.ALREADY_SIGNED_IN);
         }
     }
 }

--- a/src/main/java/io/powerrangers/backend/service/UserDetailsFactory.java
+++ b/src/main/java/io/powerrangers/backend/service/UserDetailsFactory.java
@@ -1,6 +1,9 @@
 package io.powerrangers.backend.service;
 
 import io.powerrangers.backend.dto.UserDetails;
+import io.powerrangers.backend.exception.AuthTokenException;
+import io.powerrangers.backend.exception.CustomException;
+import io.powerrangers.backend.exception.ErrorCode;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -39,7 +42,7 @@ public class UserDetailsFactory {
                         .attributes(attributes)
                         .build();
             }
-            default -> throw new IllegalArgumentException("Unsupported provider: " + providerId);
+            default -> throw new AuthTokenException(ErrorCode.UNSUPPORTED_PROVIDER, providerId);
         }
     }
 }

--- a/src/main/java/io/powerrangers/backend/service/UserService.java
+++ b/src/main/java/io/powerrangers/backend/service/UserService.java
@@ -10,6 +10,7 @@ import io.powerrangers.backend.dto.UserGetProfileResponseDto;
 import io.powerrangers.backend.dto.UserUpdateProfileRequestDto;
 import io.powerrangers.backend.entity.RefreshToken;
 import io.powerrangers.backend.entity.User;
+import io.powerrangers.backend.exception.AuthTokenException;
 import io.powerrangers.backend.exception.CustomException;
 import io.powerrangers.backend.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
@@ -39,7 +40,6 @@ public class UserService {
     }
 
     public boolean identified(Long userId) {
-        log.info("identified() 비교 중: {} vs {}", ContextUtil.getCurrentUserId(), userId);
         return ContextUtil.getCurrentUserId().equals(userId);
     }
 
@@ -117,7 +117,7 @@ public class UserService {
 
     private void findRefreshTokenAndAddToBlackList(Long userId) {
         RefreshToken refreshToken = refreshTokenRepositoryAdapter.findValidRefreshToken(userId)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));
+                .orElseThrow(() -> new AuthTokenException(ErrorCode.UNAUTHORIZED));
 
         String refreshTokenValue = refreshToken.getRefreshToken();
 
@@ -131,7 +131,7 @@ public class UserService {
         refreshTokenValue = refreshTokenValue.substring(7);
 
         if(!jwtProvider.validateToken(refreshTokenValue)){
-            throw new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.");
+            throw new AuthTokenException(ErrorCode.INVALID_TOKEN);
         }
 
         TokenBody tokenBody = jwtProvider.parseToken(refreshTokenValue);
@@ -139,10 +139,10 @@ public class UserService {
         Role role = Role.valueOf(tokenBody.getRole());
 
         RefreshToken refreshToken = refreshTokenRepositoryAdapter.findValidRefreshToken(userId)
-                .orElseThrow(() -> new IllegalArgumentException("인증에 실패 했습니다."));
+                .orElseThrow(() -> new AuthTokenException(ErrorCode.UNAUTHORIZED));
 
         if(!refreshTokenValue.equals(refreshToken.getRefreshToken())){
-            throw new IllegalArgumentException("인증에 실패 했습니다.");
+            throw new AuthTokenException(ErrorCode.UNAUTHORIZED);
         }
         String reissueAccessToken = jwtProvider.issueAccessToken(userId, role);
         return reissueAccessToken;


### PR DESCRIPTION
## 🛰️ Issue Number
- #56 

## 🪐 작업 내용
### 1. 이미지 예외 처리 
기존 Controller에서 `S3Service`를 통해 업로드하는 부분은 **비즈니스 로직에 가깝다**고 생각되어 Service단으로 넘겼습니다.
내부 Service 로직은 기존에 있던 코드와 동일합니다. 
```java
String imageUrl = taskService.uploadTaskImage(file, taskId);
```
- 컨트롤러에서는 `uploadTaskImage` 호출

```java
private void validFile(MultipartFile file) {
    if (file == null || file.isEmpty()) {
        throw new CustomException(ErrorCode.INVALID_REQUEST);
    }
    if (!file.getContentType().startsWith("image/")) {
        throw new CustomException(ErrorCode.UNSUPPORTED_RESOURCE);
    }
}
```
- 파일이 비었을 때는 `400 Bad Request` 응답
- 파일이 이미지 파일이 아닐 경우, `415 Unsupported Media Type` 응답

### 2. 인증 관련 예외

#### 새로운 커스텀 예외 : AuthTokenException
- 구조는 `CustomException`과 동일합니다. 다만, 인증 관련 예외를 주는 건 구분을 좀 해야할 것 같아서 커스텀 예외를 하나 더 만들었습니다. 

#### ☄️ EntryPoint 시도
- 필터에서 발생하는 예외는 `GlobalExceptionHandler`가 잡아줄 수 없기 때문에 Security에서 예외 처리 필터를 추가하여 exceptionHandling Entry Point를 만들어줘야 한다. 
```java
http
    .exceptionHandling()
    .authenticationEntryPoint(customAuthenticationEntryPoint);
``` 
- 그래서 시도해보았으나.. Oauth2 로그인 자체도 막힙니다.. 그래서, 이 부분도 필요한 `url`을 `permitAll`로 넣어주고 수정을 해보려고 했으나, Security에서 건드려야 할 부분이 많은 것 같아 필터 내부에 예외 응답을 내려줄 수 있는 메서드를 만들었습니다.

#### 필터 내에서 발생할 수 있는 예외
1. UserDetailsFactory 
  - AuthTokenException : 지원하지 않는 제공자일 때
    - `default -> throw new AuthTokenException(ErrorCode.UNSUPPORTED_PROVIDER, providerId);`
2. CustomOauth2UserService 
  - AuthTokenException : 유저가 이미 다른 제공자로 가입한 적이 있을 때
    - `throw new AuthTokenException(ErrorCode.ALREADY_LOGGED_IN);`
  - AuthTokenException : 유저 아이디에 맞는 유저가 없을 때
    - `User user = userRepository.findById(userId).orElseThrow(
                () -> new AuthTokenException(ErrorCode.USER_NOT_FOUND));`

- 1, 2번의 경우 `try-catch` 문에서 `AuthTokenException` 이 잡히도록 구현했습니다.

3. JwtProvider -> JwtException, IllegalStateException, Exception : 토큰이 유효하지 않을 때
즉, `validate()`에서 `false`가 반환될 때는, else문에서 `throw new AuthTokenException(ErrorCode.INVALID_TOKEN);` 예외 발생

- 3번의 경우, 조건문에서 예외를 던지고, 아래의 catch문에 잡히도록 구현했습니다.

#### 예외 핸들링 `handleAuthTokenException` 메서드
```java
String message = e.getErrorCode().getMessage();
if(!Objects.equals(e.getProvider(), null)){
    message += " : " + e.getProvider();
}
response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
response.setContentType("application/json");
response.setCharacterEncoding("UTF-8");
response.getWriter().write(
        String.format("{\"errorCode\": \"%s\", \"message\": \"%s\"}",
                e.getErrorCode().getStatus(), message)
);
```
- 던진 예외가 가지고 있는 예외코드의 메세지를 `message`에 담습니다. 이에 따라 `INVALID_TOKEN`, `USER_NOT_FOUND`, `UNSUPPORTED_PROVIDER`, `ALREADY_SIGNED_IN` 의 에러 코드와 알맞은 메세지를 내려줄 수 있습니다. 
- `response`에 응답코드를 설정해줍니다. 
  - `HttpServletResponse.SC_UNAUTHORIZED`는 `HttpStatus.UNAUTHORIZED`처럼 401 코드를 나타내지만, 서블릿 수준에서 응답 코드를 줄 때 사용합니다.

#### 예외 통일하고 난 후, 포스트맨 결과

기존 필터에서 예외가 났을 때 (혹은, 커스텀되지 않은 예외 발생 시) : 
<img width="725" alt="스크린샷 2025-05-15 오전 11 19 03" src="https://github.com/user-attachments/assets/43340de2-a900-4a41-b678-d85e9b3fc929" />

변경 후 :
<img width="369" alt="스크린샷 2025-05-15 오전 11 19 08" src="https://github.com/user-attachments/assets/1be576eb-55e0-45d0-82e3-a7322a0a60d0" />

### 3. UserService 예외 처리

인증 관련 예외에서는 `AuthTokenException`으로 바꿔주었고, 
- 아예 유효한 토큰이 없을 땐, `UNAUTHORIZED`
- 토큰의 유효성을 검사하고 실패했을 땐, `INVALID_TOKEN`
을 주도록 하였습니다.

이해 안되시는 부분있으면 질문해주세요 !

## 📚 Reference


## ✅ Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [X] 테스트 코드를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?