### PR TITLE
Feat : 공개 범위 설정에 따라 할 일, 할 일 인증 이미지 조회 API 구현

### DIFF
--- a/src/main/java/io/powerrangers/backend/config/Oauth2SuccessHandler.java
+++ b/src/main/java/io/powerrangers/backend/config/Oauth2SuccessHandler.java
@@ -5,6 +5,7 @@ import io.powerrangers.backend.dto.TokenPair;
 import io.powerrangers.backend.dto.UserDetails;
 import io.powerrangers.backend.entity.RefreshToken;
 import io.powerrangers.backend.entity.User;
+import io.powerrangers.backend.exception.AuthTokenException;
 import io.powerrangers.backend.exception.CustomException;
 import io.powerrangers.backend.exception.ErrorCode;
 import io.powerrangers.backend.service.CookieFactory;
@@ -42,7 +43,7 @@ public class Oauth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                                         Authentication authentication) throws IOException, ServletException {
         UserDetails principal = (UserDetails) authentication.getPrincipal();
         User findUser = userRepository.findById(principal.getId()).orElseThrow(
-                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                () -> new AuthTokenException(ErrorCode.USER_NOT_FOUND));
 
         String accessToken;
         String refreshToken;

--- a/src/main/java/io/powerrangers/backend/controller/TaskController.java
+++ b/src/main/java/io/powerrangers/backend/controller/TaskController.java
@@ -55,14 +55,20 @@ public class TaskController {
     }
 
     @PatchMapping("/{taskId}/image")
-    public ResponseEntity<?> uploadImage(@RequestPart("image") MultipartFile file, @PathVariable Long taskId, @RequestPart TaskCreateRequestDto dto) throws IOException {
+    public ResponseEntity<BaseResponse<String>> uploadImage(@RequestPart("image") MultipartFile file, @PathVariable Long taskId) throws IOException {
         String imageUrl = taskService.uploadTaskImage(file, taskId);
-        return ResponseEntity.ok().body(imageUrl);
+        return BaseResponse.success(SuccessCode.MODIFIED_SUCCESS, imageUrl);
     }
 
     @GetMapping("/{userId}/images")
     public ResponseEntity<BaseResponse<List<TaskImageResponseDto>>> getTaskImages(@PathVariable Long userId) {
-        return BaseResponse.success(SuccessCode.GET_SUCCESS,taskService.getTaskImages(userId));
+        return BaseResponse.success(SuccessCode.GET_SUCCESS, taskService.getTaskImages(userId));
+    }
+
+    // TODO : 어떤 방식으로 하는 게 좋을지 다시 의논해보기
+    @GetMapping
+    public ResponseEntity<BaseResponse<TaskResponseDto>> getTaskByImage(@RequestParam String imageUrl) {
+        return BaseResponse.success(SuccessCode.GET_SUCCESS, taskService.getTaskByImage(imageUrl));
     }
 }
 

--- a/src/main/java/io/powerrangers/backend/controller/TaskController.java
+++ b/src/main/java/io/powerrangers/backend/controller/TaskController.java
@@ -3,6 +3,7 @@ package io.powerrangers.backend.controller;
 import io.powerrangers.backend.dto.BaseResponse;
 import io.powerrangers.backend.dto.SuccessCode;
 import io.powerrangers.backend.dto.TaskCreateRequestDto;
+import io.powerrangers.backend.dto.TaskImageResponseDto;
 import io.powerrangers.backend.dto.TaskResponseDto;
 import io.powerrangers.backend.dto.TaskUpdateRequestDto;
 import io.powerrangers.backend.service.S3Service;
@@ -57,6 +58,11 @@ public class TaskController {
     public ResponseEntity<?> uploadImage(@RequestPart("image") MultipartFile file, @PathVariable Long taskId, @RequestPart TaskCreateRequestDto dto) throws IOException {
         String imageUrl = taskService.uploadTaskImage(file, taskId);
         return ResponseEntity.ok().body(imageUrl);
+    }
+
+    @GetMapping("/{userId}/images")
+    public ResponseEntity<BaseResponse<List<TaskImageResponseDto>>> getTaskImages(@PathVariable Long userId) {
+        return BaseResponse.success(SuccessCode.GET_SUCCESS,taskService.getTaskImages(userId));
     }
 }
 

--- a/src/main/java/io/powerrangers/backend/dao/TaskRepository.java
+++ b/src/main/java/io/powerrangers/backend/dao/TaskRepository.java
@@ -1,11 +1,15 @@
 package io.powerrangers.backend.dao;
 
+import io.powerrangers.backend.dto.TaskImageResponseDto;
 import io.powerrangers.backend.entity.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
     List<Task> findAllByUserId(Long userId);
+    @Query("select new io.powerrangers.backend.dto.TaskImageResponseDto(t.id, t.taskImage) from Task t join t.user u where u.id = :userId")
+    List<TaskImageResponseDto> findAllTaskImagesByUserId(Long userId);
 }
 

--- a/src/main/java/io/powerrangers/backend/dao/TaskRepository.java
+++ b/src/main/java/io/powerrangers/backend/dao/TaskRepository.java
@@ -1,7 +1,12 @@
 package io.powerrangers.backend.dao;
 
 import io.powerrangers.backend.dto.TaskImageResponseDto;
+import io.powerrangers.backend.dto.TaskResponseDto;
+import io.powerrangers.backend.dto.TaskScope;
+import io.powerrangers.backend.dto.TaskStatus;
 import io.powerrangers.backend.entity.Task;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,7 +14,12 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
     List<Task> findAllByUserId(Long userId);
-    @Query("select new io.powerrangers.backend.dto.TaskImageResponseDto(t.id, t.taskImage) from Task t join t.user u where u.id = :userId")
-    List<TaskImageResponseDto> findAllTaskImagesByUserId(Long userId);
+    @Query("select t from Task t join t.user u where u.id = :userId and t.scope != 'PRIVATE'")
+    List<Task> findTasksForFollowers(Long userId);
+    @Query("select t from Task t join t.user u where u.id = :userId and t.scope = 'PUBLIC'")
+    List<Task> findTasksForPublic(Long userId);
+
+    @Query("select new io.powerrangers.backend.dto.TaskResponseDto(t.id, t.category, t.content, t.dueDate, t.status, t.taskImage, t.scope, t.user.nickname) from Task t where t.taskImage = :imageUrl")
+    Optional<TaskResponseDto> findTaskByImageUrl(String imageUrl);
 }
 

--- a/src/main/java/io/powerrangers/backend/dto/TaskImageResponseDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/TaskImageResponseDto.java
@@ -1,5 +1,6 @@
 package io.powerrangers.backend.dto;
 
+import io.powerrangers.backend.entity.Task;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,4 +11,11 @@ import lombok.Getter;
 public class TaskImageResponseDto {
     private final Long taskId;
     private final String imageUrl;
+
+    public static TaskImageResponseDto from(Task task) {
+        return TaskImageResponseDto.builder()
+                .taskId(task.getId())
+                .imageUrl(task.getTaskImage())
+                .build();
+    }
 }

--- a/src/main/java/io/powerrangers/backend/dto/TaskImageResponseDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/TaskImageResponseDto.java
@@ -1,0 +1,13 @@
+package io.powerrangers.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TaskImageResponseDto {
+    private final Long taskId;
+    private final String imageUrl;
+}

--- a/src/main/java/io/powerrangers/backend/service/CommentService.java
+++ b/src/main/java/io/powerrangers/backend/service/CommentService.java
@@ -83,7 +83,7 @@ public class CommentService {
 
     private static void validateOwner(Comment comment) {
         Long userId = ContextUtil.getCurrentUserId();
-        if(comment.getUser().getId() != userId){
+        if(!Objects.equals(comment.getUser().getId(),userId)){
             throw new CustomException(ErrorCode.NOT_THE_OWNER);
         }
     }

--- a/src/main/java/io/powerrangers/backend/service/TaskService.java
+++ b/src/main/java/io/powerrangers/backend/service/TaskService.java
@@ -107,6 +107,11 @@ public class TaskService {
             throw new CustomException(ErrorCode.UNSUPPORTED_RESOURCE);
         }
     }
+
+    public List<TaskImageResponseDto> getTaskImages(Long userId) {
+        userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return taskRepository.findAllTaskImagesByUserId(userId);
+    }
 }
 
 

--- a/src/main/java/io/powerrangers/backend/service/TaskService.java
+++ b/src/main/java/io/powerrangers/backend/service/TaskService.java
@@ -1,5 +1,7 @@
 package io.powerrangers.backend.service;
 
+import static java.util.stream.Collectors.toList;
+
 import io.powerrangers.backend.dao.UserRepository;
 import io.powerrangers.backend.dto.*;
 import io.powerrangers.backend.entity.Task;
@@ -25,6 +27,7 @@ public class TaskService {
     private final TaskRepository taskRepository;
     private final UserRepository userRepository;
     private final S3Service s3Service;
+    private final FollowService followService;
 
     @Transactional
     public void createTask(TaskCreateRequestDto dto) {
@@ -48,10 +51,11 @@ public class TaskService {
 
     @Transactional(readOnly = true)
     public List<TaskResponseDto> getTasksByUser(Long userId) {
-        return taskRepository.findAllByUserId(userId)
-                .stream()
-                .map(TaskResponseDto::from)
-                .collect(Collectors.toList());
+        List<Task> tasks = getTasksByScope(userId);
+
+        return tasks.stream()
+                .map(task -> TaskResponseDto.from(task))
+                .collect(toList());
     }
 
     @Transactional
@@ -109,8 +113,31 @@ public class TaskService {
     }
 
     public List<TaskImageResponseDto> getTaskImages(Long userId) {
+        List<Task> tasks = getTasksByScope(userId);
+        return tasks.stream()
+                .map(task -> TaskImageResponseDto.from(task))
+                .collect(toList());
+    }
+
+    private List<Task> getTasksByScope(Long userId) {
         userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        return taskRepository.findAllTaskImagesByUserId(userId);
+        TaskScope scope = followService.checkFollowingRelationship(userId);
+        List<Task> tasks;
+        if(scope.equals(TaskScope.PRIVATE)){
+            tasks = taskRepository.findAllByUserId(userId);
+        } else if (scope.equals(TaskScope.FOLLOWERS)){
+            tasks = taskRepository.findTasksForFollowers(userId);
+        } else {
+            tasks = taskRepository.findTasksForPublic(userId);
+        }
+        return tasks;
+    }
+
+    public TaskResponseDto getTaskByImage(String imageUrl) {
+        TaskResponseDto taskResponseDto = taskRepository.findTaskByImageUrl(imageUrl)
+                .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
+        
+        return taskResponseDto;
     }
 }
 

--- a/src/main/java/io/powerrangers/backend/service/UserService.java
+++ b/src/main/java/io/powerrangers/backend/service/UserService.java
@@ -73,18 +73,13 @@ public class UserService {
             throw new CustomException(ErrorCode.NOT_THE_OWNER);
         }
 
-        if(!Objects.equals(user.getNickname(), request.getNickname())){
-            if(checkNicknameDuplication(request.getNickname())){
-                throw new CustomException(ErrorCode.DUPLICATED_NICKNAME);
-            }
-            user.setNickname(request.getNickname());
+        if(checkNicknameDuplication(request.getNickname())){
+            throw new CustomException(ErrorCode.DUPLICATED_NICKNAME);
         }
-        if(!Objects.equals(user.getIntro(), request.getIntro())){
-            user.setIntro(request.getIntro());
-        }
-        if(!Objects.equals(user.getProfileImage(), request.getProfileImage())){
-            user.setProfileImage(request.getProfileImage());
-        }
+
+        user.setNickname(request.getNickname());
+        user.setIntro(request.getIntro());
+        user.setProfileImage(request.getProfileImage());
     }
 
     @Transactional


### PR DESCRIPTION
## 🛰️ Issue Number
#60 

## 🪐 작업 내용
### 1. `/tasks/{userId}`
기존에 범위에 상관없이 할 일을 조회할 수 있었던 부분을 현 로그인 사용자와 `@PathVariable`의 `userId`를 비교하여 아래와 같은 기준으로 보여주도록 하였습니다. 

![스크린샷 2025-05-16 오전 10 21 00](https://github.com/user-attachments/assets/c653c4eb-5079-48e4-9519-c1d15434f2bb)

- `getTasksByScope`를 통해 공개범위에 맞는 Task를 가져오고 `getTasksByUser` 메서드에서는 리스트를 받아 DTO에 담아주도록 했습니다.

### 2. `tasks/{userId}/images`
위와 같은 기준으로 `getTaskImages` 메서드에서 `getTasksByScope`를 호출하여 공개범위에 맞는 Task를 가져오고 호출한 메서드에서는 리스트를 `TaskImageResponseDto`에 담아주도록 했습니다.

### 3. 이미지로 할 일 조회
- 이 부분은 아직 고민 되는 부분이 있어, 구현하지 않았습니다. 이 부분은 빼고 봐주시면 좋을 것 같습니다. 

## 📚 Reference


## ✅ Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [X] 포스트맨 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?