### PR TITLE
Feat: 프론트 token 재발급 구현

### DIFF
--- a/src/main/java/io/powerrangers/backend/service/UserService.java
+++ b/src/main/java/io/powerrangers/backend/service/UserService.java
@@ -1,7 +1,5 @@
 package io.powerrangers.backend.service;
 
-import com.nimbusds.jose.proc.SecurityContext;
-import io.powerrangers.backend.dao.RefreshTokenRepository;
 import io.powerrangers.backend.dao.TokenRepository;
 import io.powerrangers.backend.dao.UserRepository;
 import io.powerrangers.backend.dto.Role;
@@ -13,17 +11,12 @@ import io.powerrangers.backend.entity.User;
 import io.powerrangers.backend.exception.AuthTokenException;
 import io.powerrangers.backend.exception.CustomException;
 import io.powerrangers.backend.exception.ErrorCode;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Slf4j
 @Service

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -44,6 +44,6 @@
 </main>
 
 <!-- ===== JavaScript ===== -->
-<script src="/js/index.js"></script>
+<script type="module" src="/js/index.js"></script>
 </body>
 </html>

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -1,3 +1,5 @@
+import { apiFetch } from "./token-reissue.js";
+
 function buildCalendar(container, date = new Date()) {
     container.innerHTML = "";
 
@@ -94,16 +96,16 @@ document.addEventListener("DOMContentLoaded", () => {
 
     document.getElementById("logoutBtn").addEventListener("click", () => {
         if (confirm("정말 로그아웃하시겠습니까?")) {
-            fetch("/users/logout", {
+            apiFetch("/users/logout", {
                 method: "POST",
-                credentials: "include", // ✅ 쿠키 전송
                 headers: {
                     "Content-Type": "application/json"
                 }
-            }).finally(() => {
-                alert("성공적으로 로그아웃 되었습니다.");
-                window.location.replace("/login"); // 뒤로 가기 방지
-            });
+            })  // (로그아웃은 access token 만료여도 재시도 불필요)
+                .finally(() => {
+                    alert("성공적으로 로그아웃 되었습니다.");
+                    window.location.replace("/login");
+                });
         }
     });
 });

--- a/src/main/resources/static/js/token-reissue.js
+++ b/src/main/resources/static/js/token-reissue.js
@@ -1,0 +1,31 @@
+// src/utils/apiFetch.js
+let refreshInFlight = null;
+
+export async function apiFetch(url, options = {}, retry = true) {
+    const cfg = { credentials: "include", ...options };
+    const resp = await fetch(url, cfg);
+
+    if (resp.status !== 401 || !retry) return resp;
+
+    if (!refreshInFlight) {
+        refreshInFlight = fetch("/users/reissue", {
+            method: "POST",
+            credentials: "include",
+        }).then(r => {
+            if (!r.ok) throw new Error("Refresh failed");
+            return r;
+        }).finally(() => {
+            refreshInFlight = null;
+        });
+    }
+
+    try {
+        await refreshInFlight;
+    } catch (_) {
+        alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+        window.location.replace("/login");
+        throw _;
+    }
+
+    return fetch(url, cfg);
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#65 

## 🪐 작업 내용
### access token 재발급 로직 구현
- 프론트 측에서 만료된 access token으로 요청을 보내면 401 예외를 만나게 되는데 이 경우 refresh token으로 access token을 재발급 받아야 합니다.
- fetch api 을 커스텀하여 재발급하는 로직을 구현했습니다.
```javascript
// src/utils/apiFetch.js
// ✅ 공유 Promise: 동시에 여러 요청에서 401이 나와도 refresh는 딱 1번만 하도록 함
let refreshInFlight = null;

// ✅ API 요청을 보낼 때 사용하는 공통 fetch 함수
export async function apiFetch(url, options = {}, retry = true) {
    // ✅ 항상 쿠키 포함해서 요청 보내기 (HttpOnly access/refresh token 쿠키용)
    const cfg = { credentials: "include", ...options };
    const resp = await fetch(url, cfg); // 🔸 첫 요청

    // ✅ access token이 만료되지 않았거나, 재시도 금지되었으면 그대로 반환
    if (resp.status !== 401 || !retry) return resp;

    // ✅ access token이 만료된 경우 (401 발생)
    // 이미 다른 요청이 refresh 중인지 확인
    if (!refreshInFlight) {
        // 🔸 refresh 요청 보내기 → /users/reissue 에서 access token 재발급 받음
        refreshInFlight = fetch("/users/reissue", {
            method: "POST",
            credentials: "include", // ✅ refresh token 쿠키를 자동으로 포함시킴
        }).then(r => {
            if (!r.ok) throw new Error("Refresh failed"); // ❌ refresh 실패
            return r; // ✅ refresh 성공
        }).finally(() => {
            refreshInFlight = null; // ✅ 완료되면 초기화
        });
    }

    try {
        // ✅ refresh 결과를 기다림
        await refreshInFlight;
    } catch (_) {
        // ❌ refresh 자체가 실패 (ex. refresh token 만료됨) → 세션 종료
        alert("세션이 만료되었습니다. 다시 로그인해주세요.");
        window.location.replace("/login");
        throw _; // 이후 로직에서 에러 처리할 수 있도록 던짐
    }

    // ✅ 새 access token이 쿠키로 재발급되었으므로, 원래 요청을 재시도함
    return fetch(url, cfg);
}

```
- 이 api를 사용하면 재발급 로직을 사용할 수 있습니다.
- 일단 로그아웃에만 적용시켜놨습니다. 추후 프론트 코드가 완성되면 이거 사용해도 좋을 듯 합니다.
### 사용법?
- 사용법은 기존과 거의 동일하게 사용할 수 있습니다.
#### 1. 사용하고자 하는 js 파일에서 import를 한다.
```javascript
import { apiFetch } from "./token-reissue.js";
```
#### 2. 이 js 파일을 사용하는 html 파일에 `type="module"`을 추가한다.
```javascript
<script type="module" src="/js/index.js"></script>
```
#### 3. 기존에 사용한 fetch -> apiFetch로 수정한다.
```javascript
document.getElementById("logoutBtn").addEventListener("click", () => {
        if (confirm("정말 로그아웃하시겠습니까?")) {
            apiFetch("/users/logout", {
                method: "POST",
                headers: {
                    "Content-Type": "application/json"
                }
            })  // (로그아웃은 access token 만료여도 재시도 불필요)
                .finally(() => {
                    alert("성공적으로 로그아웃 되었습니다.");
                    window.location.replace("/login");
                });
        }
    });
```
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?