### PR TITLE
Fix : 프로필 이미지 저장 방식 변경 및 수정

### DIFF
--- a/src/main/java/io/powerrangers/backend/controller/UserController.java
+++ b/src/main/java/io/powerrangers/backend/controller/UserController.java
@@ -8,20 +8,15 @@ import io.powerrangers.backend.service.CookieFactory;
 import io.powerrangers.backend.service.UserService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
@@ -29,12 +24,15 @@ public class UserController {
 
     private final UserService userService;
 
-    @PatchMapping("/{userId}")
+    @PatchMapping(value ="/{userId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<BaseResponse<?>> updateUserProfile(
             @PathVariable Long userId,
-            @RequestBody UserUpdateProfileRequestDto request
-    ){
-        userService.updateUserProfile(userId, request);
+            @RequestPart(value = "image", required = false) MultipartFile image,
+            @RequestPart(value = "dto") UserUpdateProfileRequestDto request
+            ){
+        log.info("nickname = " + request.getNickname());
+        log.info("intro = " + request.getIntro());
+        userService.updateUserProfile(userId, request, image);
         return BaseResponse.success(SuccessCode.MODIFIED_SUCCESS);
     }
 

--- a/src/main/java/io/powerrangers/backend/controller/UserController.java
+++ b/src/main/java/io/powerrangers/backend/controller/UserController.java
@@ -6,6 +6,8 @@ import io.powerrangers.backend.dto.UserGetProfileResponseDto;
 import io.powerrangers.backend.dto.UserUpdateProfileRequestDto;
 import io.powerrangers.backend.service.CookieFactory;
 import io.powerrangers.backend.service.UserService;
+
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +31,7 @@ public class UserController {
             @PathVariable Long userId,
             @RequestPart(value = "image", required = false) MultipartFile image,
             @RequestPart(value = "dto") UserUpdateProfileRequestDto request
-            ){
+            ) throws IOException {
         log.info("nickname = " + request.getNickname());
         log.info("intro = " + request.getIntro());
         userService.updateUserProfile(userId, request, image);

--- a/src/main/java/io/powerrangers/backend/dto/UserUpdateProfileRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/UserUpdateProfileRequestDto.java
@@ -16,8 +16,4 @@ public class UserUpdateProfileRequestDto{
     private final String nickname;
 
     private final String intro;
-
-    private final String profileImage;
-
 }
-

--- a/src/main/java/io/powerrangers/backend/service/S3Service.java
+++ b/src/main/java/io/powerrangers/backend/service/S3Service.java
@@ -48,20 +48,18 @@ public class S3Service {
         return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + fileName;
     }
 
-    public void delete(String imagePath) {
+    public void delete(String imagePath) throws IOException{
         if (imagePath == null || imagePath.isBlank()) return;
 
-        try{
-            String key = extractKeyFromUrl(imagePath);
+        String key = extractKeyFromUrl(imagePath);
 
-            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(key)
-                    .build();
-        } catch (Exception e) {
-            log.error("delete error", e);
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(deleteRequest);
+
     }
 
     private String extractKeyFromUrl(String imagePath) {

--- a/src/main/java/io/powerrangers/backend/service/S3Service.java
+++ b/src/main/java/io/powerrangers/backend/service/S3Service.java
@@ -1,16 +1,21 @@
 package io.powerrangers.backend.service;
 
+import io.powerrangers.backend.exception.CustomException;
+import io.powerrangers.backend.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
 import java.util.UUID;
 
+@Slf4j
 @Service
 public class S3Service {
 
@@ -41,6 +46,27 @@ public class S3Service {
         s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
 
         return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + fileName;
+    }
+
+    public void delete(String imagePath) {
+        if (imagePath == null || imagePath.isBlank()) return;
+
+        try{
+            String key = extractKeyFromUrl(imagePath);
+
+            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+        } catch (Exception e) {
+            log.error("delete error", e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private String extractKeyFromUrl(String imagePath) {
+        String baseUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/";
+        return imagePath.replace(baseUrl, "");
     }
 }
 

--- a/src/main/java/io/powerrangers/backend/service/UserService.java
+++ b/src/main/java/io/powerrangers/backend/service/UserService.java
@@ -61,7 +61,7 @@ public class UserService {
     }
 
     @Transactional
-    public void updateUserProfile(Long userId, UserUpdateProfileRequestDto request, MultipartFile image){
+    public void updateUserProfile(Long userId, UserUpdateProfileRequestDto request, MultipartFile image) throws IOException {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -78,29 +78,26 @@ public class UserService {
             updateUserProfileImage(user, image);
     }
 
-    private void updateUserProfileImage(User user, MultipartFile image) {
+    private void updateUserProfileImage(User user, MultipartFile image) throws IOException {
         String existingImageUrl = user.getProfileImage();
 
-        if(image == null || image.isEmpty()){
+        if (image == null || image.isEmpty()) {
             s3Service.delete(existingImageUrl);
             user.setProfileImage(null);
             return;
         }
 
-        if(!image.getContentType().startsWith("image/")){
+        if (!image.getContentType().startsWith("image/")) {
             throw new CustomException(ErrorCode.UNSUPPORTED_RESOURCE);
         }
 
-        try {
-            if(existingImageUrl != null && !existingImageUrl.isEmpty()){
-                s3Service.delete(existingImageUrl);
-            }
-
-            String uploadedImageUrl = s3Service.upload(image);
-            user.setProfileImage(uploadedImageUrl);
-        } catch (IOException e) {
-            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        // 예외 전파: try-catch 제거
+        if (existingImageUrl != null && !existingImageUrl.isEmpty()) {
+            s3Service.delete(existingImageUrl);
         }
+
+        String uploadedImageUrl = s3Service.upload(image);
+        user.setProfileImage(uploadedImageUrl);
     }
 
     @Transactional


### PR DESCRIPTION
## 🛰️ Issue Number
#67 

## 🪐 작업 내용
기존 Base64 방식으로 프로필 이미지 저장 방식에서 S3를 이용하기 위해 URL 저장 방식으로 변경

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?