### PR TITLE
Feat: 달력을 누르면 해당 날짜의 할일 리스트 조회

### DIFF
--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -1,4 +1,4 @@
-import { apiFetch } from "./token-reissue.js";
+import {apiFetch} from "./token-reissue.js";
 
 function buildCalendar(container, date = new Date()) {
     container.innerHTML = "";
@@ -71,6 +71,19 @@ function buildCalendar(container, date = new Date()) {
             dateEl.addEventListener("click", () => {
                 state.selected = thisDate;
                 render();
+
+                fetchTodosUntil(state.selected).then(todos => {
+                    console.log("받은 할일 목록:", todos);
+
+                    // 💡 예: DOM에 추가하거나 조건 분기
+                    if (todos.length === 0) {
+                        console.log("할 일이 없습니다.");
+                    } else {
+                        todos.forEach(todo => {
+                            console.log(`- ${todo.title} (마감일: ${todo.dueDate})`);
+                        });
+                    }
+                });
             });
 
             grid.appendChild(dateEl);
@@ -109,6 +122,38 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     });
 });
+
+
+async function fetchTodosUntil(date) {
+    const userId = localStorage.getItem("userId");
+    if (!userId) {
+        alert("로그인 정보가 없습니다.");
+        return [];
+    }
+
+    const dateStr = date.getFullYear() + "-" +
+        String(date.getMonth() + 1).padStart(2, '0') + "-" +
+        String(date.getDate()).padStart(2, '0');
+
+    const url = `/users/${userId}/tasks?date=${dateStr}`;
+
+    try {
+        const response = await apiFetch(url, {
+            method: "GET",
+            credentials: "include"
+        });
+
+        if (!response.ok) throw new Error("할 일 조회 실패");
+
+        const baseResponse = await response.json();
+        return baseResponse.data;
+    } catch (err) {
+        console.error(err);
+        alert("할 일 조회 중 오류 발생");
+        return [];
+    }
+}
+
 
 document.getElementById("profileBtn").addEventListener("click", () => {
     window.location.href = "/mypage";


### PR DESCRIPTION
## 🛰️ Issue Number
#71 

## 🪐 작업 내용
- 달력에서 특정 날짜를 누르면 할일 리스트로 조회해오는 기능을 추가했습니다.
![image](https://github.com/user-attachments/assets/b3da06cc-9b3a-4b21-9e29-666d15658d21)
- 아래는 구현부 중 일부입니다.
```javascript
async function fetchTodosUntil(date) {
    const userId = localStorage.getItem("userId");
    if (!userId) {
        alert("로그인 정보가 없습니다.");
        return [];
    }

    const dateStr = date.getFullYear() + "-" +
        String(date.getMonth() + 1).padStart(2, '0') + "-" +
        String(date.getDate()).padStart(2, '0');

    const url = `/users/${userId}/tasks?date=${dateStr}`;

    try {
        const response = await apiFetch(url, {
            method: "GET",
            credentials: "include"
        });

        if (!response.ok) throw new Error("할 일 조회 실패");

        const baseResponse = await response.json();
        return baseResponse.data;
    } catch (err) {
        console.error(err);
        alert("할 일 조회 중 오류 발생");
        return [];
    }
}
```

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?