### PR TITLE
Refactor: ErrorCode 통합

### DIFF
--- a/src/main/java/io/powerrangers/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/io/powerrangers/backend/config/JwtAuthenticationFilter.java
@@ -65,7 +65,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 filterChain.doFilter(request, response);
             } else {
-                throw new AuthTokenException(ErrorCode.INVALID_TOKEN);
+                throw new AuthTokenException(ErrorCode.UNAUTHORIZED);
             }
         } catch (AuthTokenException e) {
             log.error("filter 에서 문제 발생!");

--- a/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
+++ b/src/main/java/io/powerrangers/backend/exception/ErrorCode.java
@@ -10,12 +10,9 @@ public enum ErrorCode {
 
     // 400 Bad Request
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "요청 데이터가 올바르지 않습니다."),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
-    MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 없습니다."),
-    UNSUPPORTED_PROVIDER(HttpStatus.UNAUTHORIZED, "지원하지 않는 제공자입니다."),
 
     // 403 Forbidden
     NOT_THE_OWNER(HttpStatus.FORBIDDEN,"해당 작업에 대한 권한이 없습니다."),

--- a/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -44,7 +47,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MissingRequestCookieException.class)
     protected ResponseEntity<BaseResponse<?>> handleMissingRequestCookieException(MissingRequestCookieException e) {
-        return BaseResponse.error(ErrorCode.MISSING_TOKEN.getMessage(), ErrorCode.MISSING_TOKEN.getStatus());
+        log.warn("[인증 실패] 토큰 쿠키가 존재하지 않음. 원인: {}", e.getMessage());
+        return BaseResponse.error(ErrorCode.UNAUTHORIZED.getMessage(), ErrorCode.UNAUTHORIZED.getStatus());
     }
 
     @ExceptionHandler({IOException.class, Exception.class})

--- a/src/main/java/io/powerrangers/backend/service/UserDetailsFactory.java
+++ b/src/main/java/io/powerrangers/backend/service/UserDetailsFactory.java
@@ -5,9 +5,12 @@ import io.powerrangers.backend.exception.AuthTokenException;
 import io.powerrangers.backend.exception.CustomException;
 import io.powerrangers.backend.exception.ErrorCode;
 import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+@Slf4j
 @SuppressWarnings("unchecked")
 public class UserDetailsFactory {
     public static UserDetails userDetails(OAuth2User oAuth2User, String providerId) {
@@ -42,7 +45,10 @@ public class UserDetailsFactory {
                         .attributes(attributes)
                         .build();
             }
-            default -> throw new AuthTokenException(ErrorCode.UNSUPPORTED_PROVIDER, providerId);
+            default -> {
+                log.warn("[인증 실패] 지원하지 않는 providerId: {}",providerId);
+                throw new AuthTokenException(ErrorCode.UNAUTHORIZED);
+            }
         }
     }
 }

--- a/src/main/java/io/powerrangers/backend/service/UserService.java
+++ b/src/main/java/io/powerrangers/backend/service/UserService.java
@@ -131,7 +131,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public String reissueAccessToken(String refreshTokenValue){
         if(!jwtProvider.validateToken(refreshTokenValue)){
-            throw new AuthTokenException(ErrorCode.INVALID_TOKEN);
+            throw new AuthTokenException(ErrorCode.UNAUTHORIZED);
         }
 
         TokenBody tokenBody = jwtProvider.parseToken(refreshTokenValue);


### PR DESCRIPTION
## 🛰️ Issue Number
#79 

## 🪐 작업 내용
세분화되어있던 보안관련 에러코드를 통합하였습니다.

1. 인증 관련 메세지는 UNAUTHORIZED 로 통일하기로 했다. 
→ 현재 UNAUTHORIZED , MISSING_TOKEN, UNSUPPORTED_PROVIDER 를 하나로 바꾸면 좋을 것 같다. 
2. NOT_THE_OWNER , NOT_ALLOWED 
- NOT_THE_OWNER : 내가 이 할 일, 댓글의 주인이 아닌데 수정하려고 할 때
- NOT_ALLOWED : 팔로우 관계가 아닐 때, 나만 보기.. 등등 공개 범위 설정에 따라 조회가 불가할 때
→ 유지해보겠습니다. 
3. 400 에러 INVALID_TOKEN → 401 에러 UNAUTHORIZED

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?