### PR TITLE
Refactor : RequestDTO에 @Builder 삭제 및 Repository에서 DTO 사용하지 않도록 수정

### DIFF
--- a/src/main/java/io/powerrangers/backend/dao/FollowRepository.java
+++ b/src/main/java/io/powerrangers/backend/dao/FollowRepository.java
@@ -12,11 +12,11 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     boolean existsByFollowerAndFollowing(User follower, User following);
     Optional<Follow> findByFollowerAndFollowing(User follower, User following);
 
-    @Query("select new io.powerrangers.backend.dto.UserFollowResponseDto(u.id, u.nickname, u.intro, u.profileImage) from Follow f JOIN f.follower u where f.following.id = :userId")
-    List<UserFollowResponseDto> findFollowersByUser(Long userId);
+    @Query("select u from Follow f JOIN f.follower u where f.following.id = :userId")
+    List<User> findFollowersByUser(Long userId);
 
-    @Query("select new io.powerrangers.backend.dto.UserFollowResponseDto(u.id, u.nickname, u.intro, u.profileImage) from Follow f JOIN f.following u where f.follower.id = :userId")
-    List<UserFollowResponseDto> findFollowingsByUser(Long userId);
+    @Query("select u from Follow f JOIN f.following u where f.follower.id = :userId")
+    List<User> findFollowingsByUser(Long userId);
 
     @Query("select count(f) from Follow f where f.following.id = :userId")
     Long countFollowersByUser(Long userId);

--- a/src/main/java/io/powerrangers/backend/dto/FollowRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/FollowRequestDto.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor(force=true)
 public class FollowRequestDto {

--- a/src/main/java/io/powerrangers/backend/dto/LogoutRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/LogoutRequestDto.java
@@ -3,10 +3,11 @@ package io.powerrangers.backend.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @AllArgsConstructor
+@NoArgsConstructor(force = true)
 public class LogoutRequestDto {
 
     private final String refreshToken;

--- a/src/main/java/io/powerrangers/backend/dto/TaskCreateRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/TaskCreateRequestDto.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Getter
-@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor(force = true)
 public class TaskCreateRequestDto {

--- a/src/main/java/io/powerrangers/backend/dto/TaskUpdateRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/TaskUpdateRequestDto.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 
 
 @Getter
-@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor(force = true)
 public class TaskUpdateRequestDto {

--- a/src/main/java/io/powerrangers/backend/dto/UserFollowResponseDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/UserFollowResponseDto.java
@@ -1,5 +1,6 @@
 package io.powerrangers.backend.dto;
 
+import io.powerrangers.backend.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,4 +13,13 @@ public class UserFollowResponseDto {
     private String nickname;
     private String intro;
     private String profileImage;
+
+    public static UserFollowResponseDto from(User user) {
+        return UserFollowResponseDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .intro(user.getIntro())
+                .profileImage(user.getProfileImage())
+                .build();
+    }
 }

--- a/src/main/java/io/powerrangers/backend/dto/UserUpdateProfileRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/UserUpdateProfileRequestDto.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor(force = true)
 public class UserUpdateProfileRequestDto{

--- a/src/main/java/io/powerrangers/backend/dto/comment/CommentUpdateRequestDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/comment/CommentUpdateRequestDto.java
@@ -5,10 +5,11 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @AllArgsConstructor
+@NoArgsConstructor(force = true)
 public class CommentUpdateRequestDto {
     @NotBlank(message="내용을 입력해주세요.")
     private final String content;

--- a/src/main/java/io/powerrangers/backend/service/FollowService.java
+++ b/src/main/java/io/powerrangers/backend/service/FollowService.java
@@ -74,7 +74,10 @@ public class FollowService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 팔로잉에 userId가 있어야 한다.
-        return followRepository.findFollowersByUser(userId);
+        List<User> users = followRepository.findFollowersByUser(userId);
+        return users.stream()
+                .map(user -> UserFollowResponseDto.from(user))
+                .toList();
     }
 
     @Transactional(readOnly=true)
@@ -83,7 +86,10 @@ public class FollowService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 팔로워 id에 userId가 있어야 한다.
-        return followRepository.findFollowingsByUser(userId);
+        List<User> users = followRepository.findFollowingsByUser(userId);
+        return users.stream()
+                .map(user -> UserFollowResponseDto.from(user))
+                .toList();
     }
 
     @Transactional(readOnly=true)


### PR DESCRIPTION
## 🛰️ Issue Number
- #82 

## 🪐 작업 내용
1. Repository에서 데이터를 DTO가 아닌 Entity로 받아오도록 했다.
2. 빌더 어노테이션 삭제

## 📚 Reference


## ✅ Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨 테스트를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?