### PR TITLE
Refactor: 팔로우리스트, 검색페이지 버튼추가, 디자인수정

### DIFF
--- a/src/main/resources/static/css/index.css
+++ b/src/main/resources/static/css/index.css
@@ -40,6 +40,7 @@ body {
     display: flex;
     align-items: center;
     gap: 0.25rem;
+    font-family: 'LeeSeoyeon', sans-serif;
 }
 
 .logo .star {

--- a/src/main/resources/static/css/search.css
+++ b/src/main/resources/static/css/search.css
@@ -74,19 +74,19 @@
 
 .user-list-item {
     background: #ffffff;
-    border-radius: 12px;
-    margin-bottom: 1rem;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    border-radius: 18px;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .user-list-item:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+    transform: translateY(-4px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
 }
 
 .user-container {
-    padding: 1rem;
+    padding: 2rem 1.5rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -106,28 +106,24 @@
 }
 
 .user-profile-image {
-    width: 48px;
-    height: 48px;
+    width: 80px;
+    height: 80px;
     border-radius: 50%;
     object-fit: cover;
-    border: 2px solid #f0f0f0;
+    border: 3px solid #e0e0e0;
 }
 
 .user-name {
-    font-size: 1rem;
-    font-weight: 600;
-    color: #333;
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: #222;
 }
 
 .user-intro {
-    font-size: 0.875rem;
-    color: #666;
+    font-size: 1rem;
+    color: #555;
     margin: 0;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    -webkit-line-clamp: 3;
 }
 
 /* Empty and error message styles */
@@ -157,12 +153,18 @@
     }
 
     .user-container {
-        padding: 0.75rem;
+        padding: 1.2rem 0.7rem;
     }
 
     .user-profile-image {
-        width: 40px;
-        height: 40px;
+        width: 56px;
+        height: 56px;
+    }
+
+    .user-list-item {
+        border-radius: 14px;
+        margin-bottom: 1rem;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.10);
     }
 
     .follow-button {

--- a/src/main/resources/static/follow-list.html
+++ b/src/main/resources/static/follow-list.html
@@ -4,9 +4,33 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>팔로우 목록</title>
-    <link rel="stylesheet" href="css/styles.css">
+    <link rel="stylesheet" href="/css/styles.css">
+    <link rel="stylesheet" href="/css/index.css">
+    <link rel="stylesheet" href="/css/fonts.css">
 </head>
 <body>
+    <header class="header">
+        <button class="icon-btn" id="backBtn" title="뒤로 가기" style="margin-right: 0.5rem;">
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M15 18L9 12L15 6" stroke="#1E1E1E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+        </button>
+        <div class="logo" id="homeLogo" style="cursor:pointer;">
+            <span class="logo-text"> 파워레인저 <span class="star">★</span></span>
+        </div>
+        <div class="header-actions">
+            <button class="icon-btn" id="profileBtn" title="마이 페이지">
+                <svg width="54" height="51" viewBox="0 0 54 51" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M38.25 44.625V40.375C38.25 38.1207 37.3018 35.9587 35.614 34.3646C33.9261 32.7705 31.6369 31.875 29.25 31.875H11.25C8.86305 31.875 6.57387 32.7705 4.88604 34.3646C3.19821 35.9587 2.25 38.1207 2.25 40.375V44.625M51.75 44.625V40.375C51.7485 38.4917 51.0848 36.6621 49.8631 35.1737C48.6413 33.6852 46.9308 32.6221 45 32.1513M36 6.65125C37.9359 7.11939 39.6518 8.18274 40.8772 9.67366C42.1025 11.1646 42.7676 12.9983 42.7676 14.8856C42.7676 16.773 42.1025 18.6067 40.8772 20.0976C39.6518 21.5885 37.9359 22.6519 36 23.12M29.25 14.875C29.25 19.5694 25.2206 23.375 20.25 23.375C15.2794 23.375 11.25 19.5694 11.25 14.875C11.25 10.1806 15.2794 6.375 20.25 6.375C25.2206 6.375 29.25 10.1806 29.25 14.875Z" stroke="#1E1E1E" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </button>
+            <button class="icon-btn" id="logoutBtn" title="로그 아웃">
+                <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M18 42H10C8.93913 42 7.92172 41.5786 7.17157 40.8284C6.42143 40.0783 6 39.0609 6 38V10C6 8.93913 6.42143 7.92172 7.17157 7.17157C7.92172 6.42143 8.93913 6 10 6H18M32 34L42 24M42 24L32 14M42 24H18" stroke="#1E1E1E" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </button>
+        </div>
+    </header>
     <div class="follow-nav">
         <button class="follow-nav-button active" data-tab="followers">팔로워</button>
         <button class="follow-nav-button" data-tab="following">팔로잉</button>

--- a/src/main/resources/static/js/follow.js
+++ b/src/main/resources/static/js/follow.js
@@ -176,4 +176,35 @@ document.addEventListener('DOMContentLoaded', () => {
         loadFollowList('followers');
         loadFollowList('following');
     }
+
+    // ===== Header actions =====
+    const logo = document.getElementById('homeLogo');
+    if (logo) {
+        logo.addEventListener('click', () => {
+            window.location.href = '/index.html';
+        });
+    }
+    const profileBtn = document.getElementById('profileBtn');
+    if (profileBtn) {
+        profileBtn.addEventListener('click', () => {
+            window.location.href = '/mypage';
+        });
+    }
+    const logoutBtn = document.getElementById('logoutBtn');
+    if (logoutBtn) {
+        logoutBtn.addEventListener('click', () => {
+            if (typeof AUTH !== 'undefined' && AUTH.logout) {
+                AUTH.logout();
+            } else {
+                window.location.replace('/loginPage');
+            }
+        });
+    }
+
+    const backBtn = document.getElementById('backBtn');
+    if (backBtn) {
+        backBtn.addEventListener('click', function() {
+            window.history.back();
+        });
+    }
 }); 

--- a/src/main/resources/static/js/search.js
+++ b/src/main/resources/static/js/search.js
@@ -125,8 +125,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-
-
     // 검색 실행 함수
     async function performSearch() {
         const searchTerm = searchInput.value.trim();
@@ -174,4 +172,28 @@ document.addEventListener('DOMContentLoaded', () => {
             performSearch();
         }
     });
+
+    // ===== Header actions =====
+    const logo = document.getElementById('homeLogo');
+    if (logo) {
+        logo.addEventListener('click', () => {
+            window.location.href = '/index.html';
+        });
+    }
+    const profileBtn = document.getElementById('profileBtn');
+    if (profileBtn) {
+        profileBtn.addEventListener('click', () => {
+            window.location.href = '/mypage';
+        });
+    }
+    const logoutBtn = document.getElementById('logoutBtn');
+    if (logoutBtn) {
+        logoutBtn.addEventListener('click', () => {
+            if (typeof AUTH !== 'undefined' && AUTH.logout) {
+                AUTH.logout();
+            } else {
+                window.location.replace('/loginPage');
+            }
+        });
+    }
 }); 

--- a/src/main/resources/static/search.html
+++ b/src/main/resources/static/search.html
@@ -7,10 +7,11 @@
     <link rel="stylesheet" href="/css/styles.css">
     <link rel="stylesheet" href="/css/search.css">
     <link rel="stylesheet" href="/css/index.css">
+    <link rel="stylesheet" href="/css/fonts.css">
 </head>
 <body>
     <header class="header">
-        <div class="logo">
+        <div class="logo" id="homeLogo" style="cursor:pointer;">
             <span class="logo-text"> 파워레인저 <span class="star">★</span></span>
         </div>
 


### PR DESCRIPTION
## 🛰️ Issue Number

#103 
## 🪐 작업 내용

검색 창에서 홈 버튼 추가 (로고 눌렀을 때), 로그아웃, 마이페이지 버튼 링크 작동하게
검색 결과 회색 박스 크게
팔로우 목록 보는 곳에서도 뒤로가기, 홈 버튼 구현

-----추후 구현-----
search, follow-list 둘 다 친구 할 일 페이지로 넘어갈 수 있도록

검색페이지 글꼴 통합했으며, 홈버튼을 따로 두지 않고 로고를 누르면 홈으로 이동합니다.
마이페이지, 로그아웃 아이콘 활성화되었습니다.
<img width="1698" alt="image" src="https://github.com/user-attachments/assets/94461d61-195e-4a37-9c01-fe57d9993ec4" />

팔로우목록 창도 디자인 수정되었으며 가운데에 로고 누를시 홈, 왼쪽상단의 뒤로가기 누르면 전의 히스토리페이지로 이동합니다.
글꼴 통합했고 위의 아이콘 모두 정상 작동하며, 프로필 크기 회색박스 늘렸습니다.
<img width="1704" alt="image" src="https://github.com/user-attachments/assets/536c19ae-209d-4b88-b6b9-cb2a4a65df90" />

추후에 다른사람의 할 일 페이지 구현이 완료되면 검색, 팔로우리스트 모두 프로필 클릭하여 넘어갈 수 있도록 구현하겠습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?