### PR TITLE
Refactor : 다른 페이지에서 메인 페이지 접근 시 자동으로 오늘 할 일 목록을 랜더링

### DIFF
--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -6,7 +6,7 @@ function buildCalendar(container, date = new Date()) {
     const state = {
         today: new Date(),
         current: new Date(date.getFullYear(), date.getMonth(), 1),
-        selected: null,
+        selected: new Date(),
     };
 
     const header = document.createElement("div");
@@ -88,12 +88,16 @@ function buildCalendar(container, date = new Date()) {
     });
 
     render();
+    fetchTodosUntil(state.selected);
 }
 
 
 document.addEventListener("DOMContentLoaded", () => {
     const calendarContainer = document.getElementById("calendar");
     buildCalendar(calendarContainer);
+
+    // 페이지 로드 시 오늘 날짜의 할 일을 자동으로 가져옵니다
+    fetchAndRenderTasks(new Date())
 
     document.getElementById("logoutBtn").addEventListener("click", () => {
         if (confirm("정말 로그아웃하시겠습니까?")) {

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -20,12 +20,6 @@ document.addEventListener("DOMContentLoaded", () => {
         const rawDateTime = document.getElementById("dueDate").value
         const dueDate = rawDateTime ? `${rawDateTime}:00` : null
 
-        let dateObj = null
-        if (rawDateTime) {
-            const dateOnlyStr = rawDateTime.split("T")[0]
-            dateObj = new Date(dateOnlyStr)
-        }
-
         const taskData = {
             category: document.getElementById("category").value,
             content: document.getElementById("content").value,
@@ -38,8 +32,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 method: "POST",
                 body: JSON.stringify(taskData),
             })
-
-            if (!res.ok) throw new Error("할 일 추가 실패")
+            if (!res.ok) throw new Error("마감일을 지금보다 이후 시간으로 설정해주세요.")
 
             await fetchAndRenderTasks(new Date())
             form.reset()
@@ -293,7 +286,7 @@ async function toggleTaskStatus(taskId, isChecked) {
         return
     }
     if (task.taskImage) {
-        alert("인증 이미지가 있는 할 일은 미완료 상태일 수 없습니다.")
+        alert("완료 인증 이미지가 있는 할 일은 미완료 상태로 변경할 수 없습니다.")
         return
     }
 
@@ -426,11 +419,16 @@ async function deleteTask(taskId) {
     }
 
     if (task.taskImage) {
-        alert("인증 이미지가 있는 할 일은 삭제할 수 없습니다.")
+        alert("완료 인증 이미지가 있는 할 일은 삭제할 수 없습니다.")
         return
     }
 
-    const confirmed = confirm("정말 삭제하시겠습니까?")
+    const lastChar = task.content[task.content.length - 1];
+    const code = lastChar.charCodeAt(0);
+    const fin = (code - 0xac00) % 28;
+    const particle = (fin === 0) ? "를":"을";
+    const confirmed = confirm(`정말 "${task.content}"${particle} 삭제하시겠습니까?`);
+
     if (!confirmed) return
 
     try {
@@ -462,7 +460,7 @@ async function uploadImage(taskId) {
         return
     }
     if (task.status !== "COMPLETE") {
-        alert("할 일이 완료된 상태에서만 인증 사진을 업로드할 수 있습니다.")
+        alert("완료 인증 사진은 할 일을 완료한 후 업로드할 수 있습니다.")
         return
     }
 


### PR DESCRIPTION
## 🛰️ Issue Number
#114 

## 🪐 작업 내용
팔로우 리스트, 마이페이지 등 다른 페이지에서 메인페이지로 접근 시 자동으로 오늘 날짜 기준 할 일 목록을 랜더링해서 보여줍니다

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?