### PR TITLE
Feat: 프로필 클릭시 해당 사용자의 할 일 목록으로 이동 버튼 활성화

### DIFF
--- a/src/main/resources/static/css/search.css
+++ b/src/main/resources/static/css/search.css
@@ -90,6 +90,12 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.user-container:hover {
+    background: #f2c3ca33;
 }
 
 .user-info {

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -9,6 +9,12 @@
     margin: 8px 0;
     width: 100%;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.user-container:hover {
+    background: #f2c3ca33;
 }
 
 .user-info {

--- a/src/main/resources/static/js/follow.js
+++ b/src/main/resources/static/js/follow.js
@@ -57,7 +57,7 @@ async function loadFollowList(type) {
             const isSelf = user.id.toString() === localStorage.getItem('userId');
             return `
                 <li class="user-list-item">
-                    <div class="user-container">
+                    <div class="user-container" data-user-id="${user.id}">
                         <div class="user-info">
                             <img src="${user.profileImage || '/images/default-profile.png'}" 
                                  alt="사용자 프로필" 
@@ -80,6 +80,7 @@ async function loadFollowList(type) {
         }).join('');
 
         attachFollowButtonListeners();
+        attachProfileClickListeners();
     } catch (error) {
         console.error(`${type} 목록 로드 중 오류 발생:`, error);
         const targetElement = type === 'followers' ? followersListElem : followingListElem;
@@ -144,6 +145,21 @@ function attachFollowButtonListeners() {
             } catch (error) {
                 console.error('팔로우 처리 중 오류 발생:', error);
                 alert(error.message || '팔로우 처리 중 오류가 발생했습니다.');
+            }
+        });
+    });
+}
+
+// 프로필 클릭 시 해당 유저의 할 일 목록으로 이동
+function attachProfileClickListeners() {
+    const containers = document.querySelectorAll('.user-container');
+    containers.forEach(container => {
+        container.addEventListener('click', function(e) {
+            // 팔로우 버튼 클릭 시는 무시
+            if (e.target.closest('.follow-button')) return;
+            const userId = container.dataset.userId;
+            if (userId) {
+                window.location.href = `/user.html?userId=${userId}`;
             }
         });
     });

--- a/src/main/resources/static/js/search.js
+++ b/src/main/resources/static/js/search.js
@@ -56,16 +56,16 @@ document.addEventListener('DOMContentLoaded', () => {
         searchResults.innerHTML = users.map(user => {
             console.log("검색 결과 user:", user);
             const isFollowing = currentUserFollowings.some(following => following.id === user.userId);
-            const isSelf = String(user.userId) === currentUserId;
+            const isSelf = String(user.userId) === localStorage.getItem('userId');
             
             return `
                 <li class="user-list-item">
-                    <div class="user-container">
+                    <div class="user-container" data-user-id="${user.userId}">
                         <div class="user-info">
-                            <img src="${user.profileImage || 'images/default-profile.png'}" 
+                            <img src="${user.profileImage || '/images/default-profile.png'}" 
                                  alt="사용자 프로필" 
                                  class="user-profile-image"
-                                 onerror="this.src='images/default-profile.png'">
+                                 onerror="this.src='/images/default-profile.png'">
                             <div class="user-details">
                                 <span class="user-name">${user.nickname}</span>
                                 ${user.intro ? `<p class="user-intro">${user.intro}</p>` : ''}
@@ -83,6 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }).join('');
 
         attachFollowButtonListeners();
+        attachProfileClickListeners();
     }
 
     function attachFollowButtonListeners() {
@@ -120,6 +121,21 @@ document.addEventListener('DOMContentLoaded', () => {
                 } catch (error) {
                     console.error('팔로우 처리 중 오류 발생:', error);
                     alert(error.message || '팔로우 처리 중 오류가 발생했습니다.');
+                }
+            });
+        });
+    }
+
+    // 프로필 클릭 시 해당 유저의 할 일 목록으로 이동
+    function attachProfileClickListeners() {
+        const containers = document.querySelectorAll('.user-container');
+        containers.forEach(container => {
+            container.addEventListener('click', function(e) {
+                // 팔로우 버튼 클릭 시는 무시
+                if (e.target.closest('.follow-button')) return;
+                const userId = container.dataset.userId;
+                if (userId) {
+                    window.location.href = `/user.html?userId=${userId}`;
                 }
             });
         });


### PR DESCRIPTION
## 🛰️ Issue Number

#115 
## 🪐 작업 내용
팔로우 목록, 검색창에서 다른 사람의 프로필을 누르면, 그 사용자의 할 일 조회 페이지로 이동

마우스포인터를 올리게되면면 버튼이 반응하여 활성화 가능임을 알 수 있고, 클릭하면 해당 Url로 이동
<img width="1627" alt="image" src="https://github.com/user-attachments/assets/339bc48c-17e4-4902-8462-91a6bde7e887" />
현재는 해당페이지가 미구현상태라 오류가 뜨지만, 엔드포인트로 잘 이동한 모습.
<img width="642" alt="image" src="https://github.com/user-attachments/assets/6ac1a828-e32c-40bc-aeb4-166afebbc0b6" />
팔로우 , 언팔로우 기능 등 기존 기능들도 다 정상작동합니다!

follow-list 페이지도 마찬가지 !

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?