### PR TITLE
Feat: 특정 월의 날짜별 할 일 개수 조회 

### DIFF
--- a/src/main/java/io/powerrangers/backend/controller/TaskController.java
+++ b/src/main/java/io/powerrangers/backend/controller/TaskController.java
@@ -1,10 +1,6 @@
 package io.powerrangers.backend.controller;
 
-import io.powerrangers.backend.dto.BaseResponse;
-import io.powerrangers.backend.dto.TaskCreateRequestDto;
-import io.powerrangers.backend.dto.TaskImageResponseDto;
-import io.powerrangers.backend.dto.TaskResponseDto;
-import io.powerrangers.backend.dto.TaskUpdateRequestDto;
+import io.powerrangers.backend.dto.*;
 import io.powerrangers.backend.service.TaskService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -67,6 +63,16 @@ public class TaskController {
     public ResponseEntity<BaseResponse<Void>> postpone(@PathVariable Long taskId) {
         taskService.postpone(taskId);
         return BaseResponse.success(HttpStatus.OK);
+    }
+
+    @GetMapping("/summary")
+    public ResponseEntity<BaseResponse<TaskSummaryResponseDto>> getTaskSummary(
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam Long userId
+    ) {
+        TaskSummaryResponseDto result = taskService.getMonthlyTaskSummary(userId, year, month);
+        return BaseResponse.success(HttpStatus.OK, result);
     }
 }
 

--- a/src/main/java/io/powerrangers/backend/dao/FollowRepository.java
+++ b/src/main/java/io/powerrangers/backend/dao/FollowRepository.java
@@ -1,12 +1,12 @@
 package io.powerrangers.backend.dao;
 
-import io.powerrangers.backend.dto.UserFollowResponseDto;
 import io.powerrangers.backend.entity.Follow;
 import io.powerrangers.backend.entity.User;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     boolean existsByFollowerAndFollowing(User follower, User following);
@@ -22,6 +22,5 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     Long countFollowersByUser(Long userId);
     @Query("select count(f) from Follow f where f.follower.id = :userId")
     Long countFollowingsByUser(Long userId);
-
-    boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
+    
 }

--- a/src/main/java/io/powerrangers/backend/dao/FollowRepository.java
+++ b/src/main/java/io/powerrangers/backend/dao/FollowRepository.java
@@ -22,4 +22,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     Long countFollowersByUser(Long userId);
     @Query("select count(f) from Follow f where f.follower.id = :userId")
     Long countFollowingsByUser(Long userId);
+
+    boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
 }

--- a/src/main/java/io/powerrangers/backend/dao/TaskRepository.java
+++ b/src/main/java/io/powerrangers/backend/dao/TaskRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
     List<Task> findAllByUserId(Long userId);
@@ -18,5 +19,25 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     List<Task> findTasksForFollowers(Long userId);
     @Query("select t from Task t join t.user u where u.id = :userId and t.scope = 'PUBLIC'")
     List<Task> findTasksForPublic(Long userId);
+
+    @Query("""
+    SELECT FUNCTION('DATE', t.dueDate), COUNT(t)
+    FROM Task t
+    WHERE t.user.id = :targetUserId
+      AND t.dueDate BETWEEN :start AND :end
+      AND (
+          (:scope = 'PUBLIC' AND t.scope = 'PUBLIC')
+          OR (:scope = 'FOLLOWERS' AND (t.scope = 'PUBLIC' OR t.scope = 'FOLLOWERS'))
+          OR (:scope = 'PRIVATE' AND t.user.id = :currentUserId)
+      )
+    GROUP BY FUNCTION('DATE', t.dueDate)
+""")
+    List<Object[]> countTasksByDateWithScope(
+            @Param("targetUserId") Long targetUserId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            @Param("scope") String scope,
+            @Param("currentUserId") Long currentUserId);
+
 }
 

--- a/src/main/java/io/powerrangers/backend/dto/TaskSummaryResponseDto.java
+++ b/src/main/java/io/powerrangers/backend/dto/TaskSummaryResponseDto.java
@@ -1,0 +1,21 @@
+package io.powerrangers.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class TaskSummaryResponseDto {
+    private int year;
+    private int month;
+    private List<DailySummary> dailySummaries;
+
+    @Getter
+    @AllArgsConstructor
+    public static class DailySummary {
+        private String date;
+        private int taskCount;
+    }
+}

--- a/src/main/java/io/powerrangers/backend/service/FollowService.java
+++ b/src/main/java/io/powerrangers/backend/service/FollowService.java
@@ -139,13 +139,4 @@ public class FollowService {
                 .build();
     }
 
-    public TaskScope checkScope(Long currentUserId, Long targetUserId) {
-        if (currentUserId.equals(targetUserId)) {
-            return TaskScope.PRIVATE;
-        }
-        if (followRepository.existsByFollowerIdAndFollowingId(currentUserId, targetUserId)) {
-            return TaskScope.FOLLOWERS;
-        }
-        return TaskScope.PUBLIC;
-    }
 }

--- a/src/main/java/io/powerrangers/backend/service/FollowService.java
+++ b/src/main/java/io/powerrangers/backend/service/FollowService.java
@@ -138,4 +138,14 @@ public class FollowService {
                 .followingCount(followingsOfUser)
                 .build();
     }
+
+    public TaskScope checkScope(Long currentUserId, Long targetUserId) {
+        if (currentUserId.equals(targetUserId)) {
+            return TaskScope.PRIVATE;
+        }
+        if (followRepository.existsByFollowerIdAndFollowingId(currentUserId, targetUserId)) {
+            return TaskScope.FOLLOWERS;
+        }
+        return TaskScope.PUBLIC;
+    }
 }

--- a/src/main/java/io/powerrangers/backend/service/TaskService.java
+++ b/src/main/java/io/powerrangers/backend/service/TaskService.java
@@ -15,7 +15,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -147,6 +152,36 @@ public class TaskService {
         task.setDueDate(task.getDueDate().plusHours(24));
         taskRepository.save(task);
     }
+
+    public TaskSummaryResponseDto getMonthlyTaskSummary(Long targetUserId, int year, int month) {
+        Long currentUserId = ContextUtil.getCurrentUserId();
+
+        TaskScope scope = followService.checkScope(currentUserId, targetUserId);
+
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+
+        List<Object[]> result = taskRepository.countTasksByDateWithScope(
+                targetUserId, start.atStartOfDay(), end.atTime(23, 59, 59),
+                scope.name(), currentUserId);
+
+        Map<LocalDate, Long> countMap = new HashMap<>();
+        for (Object[] row : result) {
+            LocalDate date = ((java.sql.Date) row[0]).toLocalDate();
+            Long count = (Long) row[1];
+            countMap.put(date, count);
+        }
+
+        List<TaskSummaryResponseDto.DailySummary> dailySummaries = new ArrayList<>();
+        for (int day = 1; day <= start.lengthOfMonth(); day++) {
+            LocalDate currentDate = start.withDayOfMonth(day);
+            int count = countMap.getOrDefault(currentDate, 0L).intValue();
+            dailySummaries.add(new TaskSummaryResponseDto.DailySummary(currentDate.toString(), count));
+        }
+
+        return new TaskSummaryResponseDto(year, month, dailySummaries);
+    }
+
 }
 
 

--- a/src/main/java/io/powerrangers/backend/service/TaskService.java
+++ b/src/main/java/io/powerrangers/backend/service/TaskService.java
@@ -156,7 +156,7 @@ public class TaskService {
     public TaskSummaryResponseDto getMonthlyTaskSummary(Long targetUserId, int year, int month) {
         Long currentUserId = ContextUtil.getCurrentUserId();
 
-        TaskScope scope = followService.checkScope(currentUserId, targetUserId);
+        TaskScope scope = followService.checkScopeWithUser(targetUserId);
 
         LocalDate start = LocalDate.of(year, month, 1);
         LocalDate end = start.withDayOfMonth(start.lengthOfMonth());


### PR DESCRIPTION
## 🛰️ Issue Number
#119 

## 🪐 작업 내용
더미데이터로 태스크를 다음과 같이 담았다.
<img width="864" alt="image" src="https://github.com/user-attachments/assets/ee32932e-0106-48cd-8615-e1bdc46216f6" />
이 상태로 tasks/summary?userId=2&year=2025&month=5 
=> 2번 사용자의 할 일 개수를 반환해보겠다.
<img width="343" alt="image" src="https://github.com/user-attachments/assets/c3556ea2-df53-4b64-8382-ed46114b2431" />
2번 사용자의 20일 태스크는 실제로 3개이지만 public인 하나만 반환이 됐다.

<img width="927" alt="image" src="https://github.com/user-attachments/assets/23ec33f6-9bf1-43f2-a561-2a1291ce1d52" />
서로 팔로잉 처리 후 똑같이 요청을 하면
<img width="350" alt="image" src="https://github.com/user-attachments/assets/3921d0a3-da50-4c25-be39-b5010c75480d" />

FOLLOWERS 스코프의 할 일 개수까지 카운트하는 모습이다.
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨 테스트를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?