### PR TITLE
Fix: 로컬스토리지 UserId 세팅

### DIFF
--- a/src/main/java/io/powerrangers/backend/controller/UserController.java
+++ b/src/main/java/io/powerrangers/backend/controller/UserController.java
@@ -4,6 +4,7 @@ import io.powerrangers.backend.dto.BaseResponse;
 import io.powerrangers.backend.dto.TaskResponseDto;
 import io.powerrangers.backend.dto.UserGetProfileResponseDto;
 import io.powerrangers.backend.dto.UserUpdateProfileRequestDto;
+import io.powerrangers.backend.service.ContextUtil;
 import io.powerrangers.backend.service.CookieFactory;
 import io.powerrangers.backend.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -78,5 +79,11 @@ public class UserController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
                 .build();
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<BaseResponse<Long>> getCurrentUserId() {
+        Long userId = ContextUtil.getCurrentUserId();
+        return BaseResponse.success(HttpStatus.OK, userId);
     }
 }

--- a/src/main/resources/static/js/initial-auth.js
+++ b/src/main/resources/static/js/initial-auth.js
@@ -1,6 +1,6 @@
 window.addEventListener("load", async function () {
     try {
-        const res = await fetch('/users/me', { credentials: "include" });
+        const res = await apiFetch('/users/me');
         if (!res.ok) throw new Error("인증 필요");
         const response = await res.json();
         localStorage.setItem("userId", response.data);

--- a/src/main/resources/static/js/initial-auth.js
+++ b/src/main/resources/static/js/initial-auth.js
@@ -1,0 +1,13 @@
+window.addEventListener("load", async function () {
+    try {
+        const res = await fetch('/users/me', { credentials: "include" });
+        if (!res.ok) throw new Error("인증 필요");
+        const response = await res.json();
+        localStorage.setItem("userId", response.data);
+        console.log("✅ userId 저장됨:", response.data);
+    } catch (e) {
+        console.error("로그인 필요:", e);
+        alert("로그인이 필요합니다.");
+        window.location.href = "/login";
+    }
+}); 

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -3,7 +3,7 @@ import {apiFetch} from "./token-reissue.js";
 // Fetch logged-in user's userId from server
 async function setUserIdFromServer() {
     try {
-        const res = await fetch('/users/me', { credentials: "include" });
+        const res = await apiFetch('/users/me');
         if (!res.ok) throw new Error("인증 필요");
         const response = await res.json();
         localStorage.setItem("userId", response.data);


### PR DESCRIPTION
## 🛰️ Issue Number
#142

## 🪐 작업 내용

현재 쿼리파라미터 기반으로 로컬스토리지 userId세팅중
=> 다른 페이지에서 다른 유저아이디의 쿼리파라미터가 들어오면 자동으로 userId가 남의 아이디로 세팅되고있음
=> 해결방안 : 로그인되어있는 사용자의 아이디를 받아 로컬스토리지에 세팅
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?