### PR TITLE
Fix : 다른 사람 페이지에서 내 할 일 우선 X, 해당 유저의 할 일이 뜨도록 하기

### DIFF
--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -1,6 +1,53 @@
 import {apiFetch} from "./token-reissue.js";
 import {fetchAndRenderTasks} from './main.js';
 
+document.addEventListener("DOMContentLoaded", () => {
+    const params = new URLSearchParams(window.location.search);
+    const currentUserId = localStorage.getItem("userId");
+    console.log("currentUserId:", currentUserId);
+
+    const targetUserId = params.get("userId");
+    console.log("targetUserId:", targetUserId);
+
+    const userIdToShow = targetUserId || currentUserId;
+    console.log("userIdToShow:", userIdToShow);
+
+    const calendarContainer = document.getElementById("calendar");
+    buildCalendar(calendarContainer, userIdToShow);
+
+    // 페이지 로드 시 오늘 날짜의 할 일을 자동으로 가져옵니다
+
+    fetchAndRenderTasks(new Date(), userIdToShow);
+
+    document.getElementById("logoutBtn").addEventListener("click", () => {
+        if (confirm("정말 로그아웃하시겠습니까?")) {
+            apiFetch("/users/logout", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                }
+            })  // (로그아웃은 access token 만료여도 재시도 불필요)
+                .finally(() => {
+                    alert("성공적으로 로그아웃 되었습니다.");
+                    localStorage.removeItem("userId");
+                    window.location.replace("/loginPage");
+                });
+        }
+    });
+
+    const logo = document.getElementById('homeLogo');
+    if (logo) {
+        logo.addEventListener('click', () => {
+            const userId = localStorage.getItem('userId');
+            if (userId) {
+                window.location.href = `/index.html?userId=${userId}`;
+            } else {
+                window.location.href = '/index.html';
+            }
+        });
+    }
+});
+
 async function fetchTaskSummary(year, month, userId) {
     const url = `/tasks/summary?userId=${userId}&year=${year}&month=${month}`;
     try {
@@ -124,45 +171,6 @@ export function buildCalendar(container, targetUserId, date = new Date()) {
 
     fetchAndRenderTasks(state.selected, targetUserId);
 }
-
-
-document.addEventListener("DOMContentLoaded", () => {
-    const currentUserId = localStorage.getItem("userId");
-    const calendarContainer = document.getElementById("calendar");
-    buildCalendar(calendarContainer, currentUserId);
-
-    // 페이지 로드 시 오늘 날짜의 할 일을 자동으로 가져옵니다
-
-    fetchAndRenderTasks(new Date(), currentUserId);
-
-    document.getElementById("logoutBtn").addEventListener("click", () => {
-        if (confirm("정말 로그아웃하시겠습니까?")) {
-            apiFetch("/users/logout", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json"
-                }
-            })  // (로그아웃은 access token 만료여도 재시도 불필요)
-                .finally(() => {
-                    alert("성공적으로 로그아웃 되었습니다.");
-                    localStorage.removeItem("userId");
-                    window.location.replace("/loginPage");
-                });
-        }
-    });
-
-    const logo = document.getElementById('homeLogo');
-    if (logo) {
-        logo.addEventListener('click', () => {
-            const userId = localStorage.getItem('userId');
-            if (userId) {
-                window.location.href = `/index.html?userId=${userId}`;
-            } else {
-                window.location.href = '/index.html';
-            }
-        });
-    }
-});
 
 document.getElementById("profileBtn").addEventListener("click", () => {
     window.location.href = "/mypage";

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -11,7 +11,7 @@ async function setUserIdFromServer() {
     } catch (e) {
         console.error("로그인 필요:", e);
         alert("로그인이 필요합니다.");
-        window.location.href = "/login";
+        window.location.href = "/loginPage";
     }
 }
 setUserIdFromServer();


### PR DESCRIPTION
## 🛰️ Issue Number
- #147 

## 🪐 작업 내용
### 문제 원인

다른 유저의 페이지 user.js 쪽에서 
```js
document.addEventListener("DOMContentLoaded", async () => {
    const calendarContainer = document.getElementById("calendar");
    buildCalendar(calendarContainer, targetUserId);
```
이렇게 해주고 있는데, 우선은 `index.js` 쪽에서도 이렇게 `targetUserID`를 잘 받고 있어. 
```js
export function buildCalendar(container, targetUserId, date = new Date()) {
    container.innerHTML = "";
```
근데, index.js에서 자동으로 오늘 내 할 일을 가져오고 있다.
```js
document.addEventListener("DOMContentLoaded", () => {
    const currentUserId = localStorage.getItem("userId");
    const calendarContainer = document.getElementById("calendar");
    buildCalendar(calendarContainer, currentUserId);

    // 페이지 로드 시 오늘 날짜의 할 일을 자동으로 가져옵니다

    fetchAndRenderTasks(new Date(), currentUserId);
```

### 해결방법 
```js
const params = new URLSearchParams(window.location.search);
    const currentUserId = localStorage.getItem("userId");
    console.log("currentUserId:", currentUserId);

    const targetUserId = params.get("userId");
    console.log("targetUserId:", targetUserId);

    const userIdToShow = targetUserId || currentUserId;
    console.log("userIdToShow:", userIdToShow);
```
URL 파라미터가 우선적으로 고려되게 만들었습니다. 
URL에 내 userId가 있으면 targetUserId가 그 값이고, 없으면 localStorage의 내 userId를 씁니다. 저희는 항상 파라미터에 값이 있어서 localStorage에서 내 아이디는 유지하되, 파라미터로 할 일을 렌더링하게 됩니다.



## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?